### PR TITLE
Fix small typo in readme.html

### DIFF
--- a/docs/readme.html
+++ b/docs/readme.html
@@ -33,7 +33,7 @@
                 <div class="navbar-header"> <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse"> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </button> <a class="navbar-brand" href="index.html">PolyGlot v 1.4</a> </div>
                 <div class="navbar-collapse collapse">
                     <ul class="nav navbar-nav navbar-right">
-                        <li><a href="https://github.com/DraqueT/PolyGlot">Githib Page</a><br>
+                        <li><a href="https://github.com/DraqueT/PolyGlot">GitHub Page</a><br>
                             <br>
                         </li>
                         <li><a href="mailto:Draquemail@gmail.com">Contact Author</a><br>


### PR DESCRIPTION
I noticed a small typo in the readme.html when I opened it. GitHub was spelled "Githib".