### PR TITLE
Improve Linux Launcher

### DIFF
--- a/docs/readme.html
+++ b/docs/readme.html
@@ -208,6 +208,12 @@
                             done through the Package Manager and search for JavaFX or the full
                             name, java-openjfx.<br>
                             <br>
+                            An example <i>PolyGlot.desktop</i> file is provided, and can be copied
+                            in <i>~/.local/share/applications/</i> so that PolyGlot can be launched
+                            from the menu or application launcher. The paths of files in entries
+                            <i>Exec</i> and <i>Icon</i> must be adapter to the location where you
+                            installed PolyGlot.
+                            <br>
                             <span style="font-weight: bold;">NOTE FOR ARCH LINUX USERS: </span>You
                             must install JFX manually to properly use PolyGlot.<br>
                             <br><span style="font-weight: bold;">NOTE FOR FEDORA USERS: </span>

--- a/miscDistributionFiles/PolyGlot.desktop
+++ b/miscDistributionFiles/PolyGlot.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=PolyGlot
+Exec=<install-dir>/PolyGlot.sh
+Terminal=false
+Icon=<install-dir>/assets/PolyGlot Logo.png
+Type=Application
+Categories=Development;Education;Science;

--- a/miscDistributionFiles/PolyGlot.sh
+++ b/miscDistributionFiles/PolyGlot.sh
@@ -2,4 +2,50 @@
 
 basedir=$(dirname $(readlink -f $0))
 
-java -jar $basedir/PolyGlot.jar
+java_version() {
+  local result
+  local java_cmd
+  if [[ -n $(type -p java) ]]
+  then
+    java_cmd=java
+  elif [[ (-n "$JAVA_HOME") && (-x "$JAVA_HOME/bin/java") ]]
+  then
+    java_cmd="$JAVA_HOME/bin/java"
+  fi
+  local IFS=$'\n'
+  if [[ -z $java_cmd ]]
+  then
+    echo "java could not be found"
+    exit 1
+  else
+    # remove \r for Cygwin
+    local lines=$("$java_cmd" -Xms32M -Xmx32M -version 2>&1 | tr '\r' '\n')
+    for line in $lines; do
+      if [[ (-z $result) && ($line = *"version \""*) ]]
+      then
+        local ver=$(echo $line | sed -e 's/.*version "\(.*\)"\(.*\)/\1/; 1q')
+        # on macOS, sed doesn't support '?'
+        if [[ $ver = "1."* ]]
+        then
+          result=$(echo $ver | sed -e 's/1\.\([0-9]*\)\(.*\)/\1/; 1q')
+        else
+          result=$(echo $ver | sed -e 's/\([0-9]*\)\(.*\)/\1/; 1q')
+        fi
+      fi
+    done
+  fi
+  echo "$result"
+}
+
+# Works for Debian-based system if installed via openjfx package
+# Could be extended to support other distribution
+JFX_DIR="/usr/share/openjfx/lib/"
+
+if [[ "$(java_version)" -ge 9 && -d "$JFX_DIR" ]]
+then
+  JAVA_OPTS="--module-path $JFX_DIR --add-modules=ALL-MODULE-PATH"
+else
+  JAVA_OPTS=""
+fi
+
+java $JAVA_OPTS -jar $basedir/PolyGlot.jar

--- a/miscDistributionFiles/PolyGlot.sh
+++ b/miscDistributionFiles/PolyGlot.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-java -jar ./PolyGlot.jar
+
+basedir=$(dirname $(readlink -f $0))
+
+java -jar $basedir/PolyGlot.jar


### PR DESCRIPTION
This contribution adds following improvements for Linux:
 - the `sh` script can be executed from any directory
 - JFX modules are added for Java >= 9 (only works for Debian based distributions for which JFX was installed via the package manager)
 - an example desktop file for adding PolyGlot to the menu or application launcher