### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/readme.html
+++ b/docs/readme.html
@@ -671,7 +671,7 @@
                             appear in the list as its label. Then there is the local language version of the 
                             phrase, its conlang translation, a transcription of its pronunciation, and relevant 
                             notes.
-                            <br>br>
+                            <br><br>
                             The pronunciation will be automatically generated if you have this feature set up 
                             in the Phonology & Text section of your language. It may also be overridden if 
                             the phrase contains words with pronunciation rule exceptions.


### PR DESCRIPTION
Noticed a missing angle bracket while looking at the 483f886. I wasn't sure a new issue would be worth it, so I made a tiny PR.
I didn't look too closely at the rest of the file for typos.