### PR TITLE
fix: some links on the website use http instead of https

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
 
         <p class="view"><a href="https://github.com/DraqueT/PolyGlot">View the Project on GitHub</a></p>
         <p class="view"><a href="https://github.com/DraqueT/PolyGlot/zipball/master">Download the <strong>Source</strong> (for developers)</a></p>
-        <p class="view"><a href="http://draquet.github.io/PolyGlot/readme.html">Read <strong>The Manual</strong></a></p>
+        <p class="view"><a href="https://draquet.github.io/PolyGlot/readme.html">Read <strong>The Manual</strong></a></p>
 
 
         <ul>
@@ -68,7 +68,7 @@
 <li>Recording and playback of spoken examples within the grammar section</li>
 <li>A useful phrasebook for commonly spoken phrases</li>
 <li>Supports exporting lexicon to Excel</li>
-<li>Interactive IPA chart with spoken examples and characters copied to clipboard (courtesy of <a href="http://www.internationalphoneticalphabet.org/">http://www.internationalphoneticalphabet.org/</a>)</li>
+<li>Interactive IPA chart with spoken examples and characters copied to clipboard (courtesy of <a href="https://www.internationalphoneticalphabet.org/">https://www.internationalphoneticalphabet.org/</a>)</li>
 <li>Language statistics window for analysis of current lexicon</li>
 <li>RTL character direction enforcement for applicable languages (useful with custom scripts)</li>
 <li>Lexical consistency check tool to ensure compliance to language rules as you evolve them</li>

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -1680,11 +1680,10 @@
                                     with Fontstruct.<br>
                                     <div align ="left">
                                         <ul>
-                                            <li><a href="http://www.fontstruct.com">Fontstruct</a></li>
+                                            <li><a href="https://www.fontstruct.com">Fontstruct</a></li>
 
-                                            <li><a href="http://fontforge.sourceforge.net/">FontForge</a></li>
-                                            <li><a href="http://www.pentacom.jp/soft/ex/font/edit_canvas.html">BitFontMaker</a></li>
-                                            <li><a href="http://www.fontconstructor.com/">FontConstructor</a><br>
+                                            <li><a href="https://fontforge.sourceforge.net/">FontForge</a></li>
+                                            <li><a href="https://www.pentacom.jp/soft/ex/font/edit_canvas.html">BitFontMaker</a></li>
                                             </li>
                                         </ul>
                                     </div>
@@ -1694,10 +1693,10 @@
                                     community of very friendly people who are passionate about creating and
                                     refining constructed languages.<br>
                                     <div align ="left"><ul>
-                                            <li><a href="http://conlang.org/">The Language Creation Society</a></li>
+                                            <li><a href="https://conlang.org/">The Language Creation Society</a></li>
 
                                             <li><a href="www.zompist.com/kit/">The Language Construction Kit</a></li>
-                                            <li><a href="http://www.reddit.com/r/conlangs/">The Reddit Conlang
+                                            <li><a href="https://www.reddit.com/r/conlangs/">The Reddit Conlang
                                                     Community</a><br>
                                             </li>
                                         </ul>
@@ -1706,8 +1705,8 @@
                                     are immensely powerful. Below are a few links that are very helpful in
                                     learning good RegEx practices.<br>
                                     <div align ="left"><ul>
-                                            <li><a href="http://regexone.com/">RegexOne</a></li>
-                                            <li><a href="http://www.regular-expressions.info/tutorial.html">Regular-Expressions
+                                            <li><a href="https://regexone.com/">RegexOne</a></li>
+                                            <li><a href="https://www.regular-expressions.info/tutorial.html">Regular-Expressions
                                                     Info</a><br>
 
                                             </li>
@@ -1738,8 +1737,8 @@
                                     PolyGlot uses IPA pronunciations sounds from the Wikimedia Commons, created by Peter Isotalo, User:Denelson83, UCLA Phonetics Lab Archive
                                     2003, User:Halibutt, User:Pmx and User:Octane, and covered under the GNU Free Documentation License<br>
                                     PolyGlot uses IPA pronunciations from the Wikimedia Commons (referenced and linked <a href="https://en.wikipedia.org/wiki/International_Phonetic_Alphabet">here</a>)<br>
-                                    PolyGlot uses font Charis, Copyright (c) 1997-2014, SIL International (http://scripts.sil.org/) with Reserved Font Names "Charis" and "SIL"<br>
-                                    PolyGlot uses iText7, which is created and owned by iText Software (http://itextpdf.com) and licensed under the AGPL license<br>
+                                    PolyGlot uses font Charis, Copyright (c) 1997-2014, SIL International (https://scripts.sil.org/) with Reserved Font Names "Charis" and "SIL"<br>
+                                    PolyGlot uses iText7, which is created and owned by iText Software (https://itextpdf.com) and licensed under the AGPL license<br>
                                     PolyGlot uses glyph manipulating code written by Stanislav Lapitsky 
                                     (http://java-sl.com/) <br>
                                     PolyGlot uses the HTML parsing library <a href="https://jsoup.org/">jsoup</a> by Jonathan Hedley


### PR DESCRIPTION
Also I removed link to FontConstructor (http://www.fontconstructor.com/), as it was invalid. I can return it there if desired.