### PR TITLE
Fix XML recovery

### DIFF
--- a/src/main/java/org/darisadesigns/polyglotlina/XMLRecoveryTool.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/XMLRecoveryTool.java
@@ -60,14 +60,20 @@ public class XMLRecoveryTool {
         }
     }
     
+    /**
+     * Fixes errors of simple tags.  
+     * i.e. tags that only contain a value and not other tags inside it
+     */
     private void fixMissingTags() {
         var tagStack = new ArrayList<String>();
         outputList = new ArrayList<>();
         boolean failures = false;
+        var prevNonBlankToken = "";
         
         
         // first element is header
         outputList.add(tokenList.get(0));
+        prevNonBlankToken = tokenList.get(1);
         
         for (int i = 1; i < tokenList.size(); i++) {
             String tag = tokenList.get(i);
@@ -81,6 +87,19 @@ public class XMLRecoveryTool {
                     if (!tagStack.isEmpty() && startTag.equals(tagStack.get(tagStack.size() - 1))) {
                         // tag is closed correctly. Remove from stack
                         tagStack.remove(tagStack.size() - 1);
+                    } else if (!tagStack.isEmpty() && !tagStack.contains(startTag)) {
+                        // Opening tag is missing
+                        failures = true;
+                        if (prevNonBlankToken.startsWith("<") && prevNonBlankToken.endsWith(">")) {
+                            // Previous token is a tag, no content for this tag (insert "<tag/>")
+                            outputList.add(new StringBuffer(startTag).insert(startTag.length() - 1, "/").toString());
+                        } else {
+                            // Insert opening tag before content
+                            outputList.add(outputList.size() - 1, startTag);
+                            // Also include closing tag
+                            outputList.add(new StringBuffer(startTag).insert(1, "/").toString());
+                        }
+                        continue;
                     } else { // Either an opening or closing tag is missing. Mark with failures
                         failures = true;
 
@@ -100,6 +119,9 @@ public class XMLRecoveryTool {
                         continue;
                     }
                 }
+            }
+            if(!tag.isBlank()) {
+                prevNonBlankToken = tag;
             }
             
             outputList.add(tag);

--- a/src/main/java/org/darisadesigns/polyglotlina/XMLRecoveryTool.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/XMLRecoveryTool.java
@@ -87,8 +87,11 @@ public class XMLRecoveryTool {
                         if (tagStack.contains(startTag)) { // if tag stack contains related opening tag, close all tags back up to opener
                             while (tagStack.contains(startTag)) {
                                 String closer = tagStack.get(tagStack.size() - 1);
+                                // If tag being closed is the current one insert at the end
+                                // Otherwise insert after content of the opening tag
+                                int idx = closer.equals(startTag) ? outputList.size() : outputList.lastIndexOf(closer) + 2;
                                 closer = new StringBuffer(closer).insert(1, "/").toString();
-                                outputList.add(closer);
+                                outputList.add(idx, closer);
                                 tagStack.remove(tagStack.size() - 1);
                             }
                         } 

--- a/src/test/java/org/darisadesigns/polyglotlina/DictCoreTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/DictCoreTest.java
@@ -170,7 +170,7 @@ public class DictCoreTest {
     
     @Test
     public void testRecoverMissingClosingXmlTags() {
-        System.out.println("DictCoreTest.testRecoverMissingOpeningXmlTags");
+        System.out.println("DictCoreTest.testRecoverMissingClosingXmlTags");
         
         try {
             core.readFile(PGTUtil.TESTRESOURCES + "missing_no_element.pgd");

--- a/src/test/java/org/darisadesigns/polyglotlina/DictCoreTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/DictCoreTest.java
@@ -176,11 +176,6 @@ public class DictCoreTest {
             core.readFile(PGTUtil.TESTRESOURCES + "missing_no_element.pgd");
             DictCore corruptCore = DummyCore.newCore();
             corruptCore.readFile(PGTUtil.TESTRESOURCES + "missing_closing_elements.pgd");
-            
-            // corrupted core will read corrupted conword *slightly* incorrectly. Corret here.
-            ConWord correctMe = corruptCore.getWordCollection().getNodeById(2);
-            String definition = correctMe.getDefinition();
-            correctMe.setDefinition(definition.substring(0, definition.length() - 3));
 
             assertEquals(core, corruptCore);
         } catch (IOException | IllegalStateException e) {

--- a/src/test/java/org/darisadesigns/polyglotlina/XMLRecoveryToolTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/XMLRecoveryToolTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020-2022, Draque Thompson, draquemail@gmail.com
+ * All rights reserved.
+ *
+ * Licensed under: MIT License
+ * See LICENSE.TXT included with this code to read the full license agreement.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.darisadesigns.polyglotlina;
+
+import java.util.Map;
+import java.util.stream.Stream;
+import org.darisadesigns.polyglotlina.XMLRecoveryTool;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ *
+ * @author Edgar
+ */
+public class XMLRecoveryToolTest {
+
+    @ParameterizedTest
+    @MethodSource("corruptedXMLProvider")
+    public void testRecoverXml(String caseName, String corrupted, String expected) {
+        System.out.printf("XMLRecoveryToolTest.testRecoverXml (%s)", caseName).println();
+        XMLRecoveryTool tool = new XMLRecoveryTool(corrupted);
+        String recover = tool.recoverXml();
+        
+        assertEquals(expected, recover);
+    }
+    
+    static Stream<Arguments> corruptedXMLProvider() {
+        return Stream.of(
+            Arguments.of(
+                "Missing definition close tag",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <dictionary>
+                    <PolyGlotVer>3.6</PolyGlotVer>
+                    <lexicon>
+                        <word>
+                            <wordId>2</wordId>
+                            <pronunciation/>
+                            <definition>definition
+                            <wordProcOverride>F</wordProcOverride>
+                            <autoDeclOverride>F</autoDeclOverride>
+                            <wordRuleOverride>F</wordRuleOverride>
+                        </word>
+                    </lexicon>
+                </dictionary>
+                """,
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <dictionary>
+                    <PolyGlotVer>3.6</PolyGlotVer>
+                    <lexicon>
+                        <word>
+                            <wordId>2</wordId>
+                            <pronunciation/>
+                            <definition>definition
+                            <wordProcOverride>F</wordProcOverride>
+                            <autoDeclOverride>F</autoDeclOverride>
+                            <wordRuleOverride>F</wordRuleOverride>
+                        </definition></word>
+                    </lexicon>
+                </dictionary>
+                """
+            ),
+            Arguments.of(
+                "Missing definition open tag",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <dictionary>
+                    <PolyGlotVer>3.6</PolyGlotVer>
+                    <lexicon>
+                        <word>
+                            <wordId>2</wordId>
+                            <pronunciation/>
+                            definition</definition>
+                            <wordProcOverride>F</wordProcOverride>
+                            <autoDeclOverride>F</autoDeclOverride>
+                            <wordRuleOverride>F</wordRuleOverride>
+                        </word>
+                    </lexicon>
+                </dictionary>
+                """,
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <dictionary>
+                    <PolyGlotVer>3.6</PolyGlotVer>
+                    <lexicon>
+                        <word>
+                            <wordId>2</wordId>
+                            <pronunciation/>
+                            definition
+                            <wordProcOverride>F</wordProcOverride>
+                            <autoDeclOverride>F</autoDeclOverride>
+                            <wordRuleOverride>F</wordRuleOverride>
+                        </word>
+                    </lexicon>
+                </dictionary>
+                """
+            )
+        );
+    }
+}

--- a/src/test/java/org/darisadesigns/polyglotlina/XMLRecoveryToolTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/XMLRecoveryToolTest.java
@@ -82,41 +82,76 @@ public class XMLRecoveryToolTest {
                 </dictionary>
                 """
             ),
-             Arguments.of(
-                 "Missing definition open tag",
-                 """
-                 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-                 <dictionary>
-                     <PolyGlotVer>3.6</PolyGlotVer>
-                     <lexicon>
-                         <word>
-                             <wordId>2</wordId>
-                             <pronunciation/>
-                             definition</definition>
-                             <wordProcOverride>F</wordProcOverride>
-                             <autoDeclOverride>F</autoDeclOverride>
-                             <wordRuleOverride>F</wordRuleOverride>
-                         </word>
-                     </lexicon>
-                 </dictionary>
-                 """,
-                 """
-                 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-                 <dictionary>
-                     <PolyGlotVer>3.6</PolyGlotVer>
-                     <lexicon>
-                         <word>
-                             <wordId>2</wordId>
-                             <pronunciation/>
-                             definition
-                             <wordProcOverride>F</wordProcOverride>
-                             <autoDeclOverride>F</autoDeclOverride>
-                             <wordRuleOverride>F</wordRuleOverride>
-                         </word>
-                     </lexicon>
-                 </dictionary>
-                 """
-             )
+            Arguments.of(
+                "Missing definition open tag",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <dictionary>
+                    <PolyGlotVer>3.6</PolyGlotVer>
+                    <lexicon>
+                        <word>
+                            <wordId>2</wordId>
+                            <pronunciation/>
+                            definition</definition>
+                            <wordProcOverride>F</wordProcOverride>
+                            <autoDeclOverride>F</autoDeclOverride>
+                            <wordRuleOverride>F</wordRuleOverride>
+                        </word>
+                    </lexicon>
+                </dictionary>
+                """,
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <dictionary>
+                    <PolyGlotVer>3.6</PolyGlotVer>
+                    <lexicon>
+                        <word>
+                            <wordId>2</wordId>
+                            <pronunciation/><definition>
+                            definition</definition>
+                            <wordProcOverride>F</wordProcOverride>
+                            <autoDeclOverride>F</autoDeclOverride>
+                            <wordRuleOverride>F</wordRuleOverride>
+                        </word>
+                    </lexicon>
+                </dictionary>
+                """
+            ),
+            Arguments.of(
+                "Missing definition open tag without content",
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <dictionary>
+                    <PolyGlotVer>3.6</PolyGlotVer>
+                    <lexicon>
+                        <word>
+                            <wordId>2</wordId>
+                            <pronunciation/>
+                            </definition>
+                            <wordProcOverride>F</wordProcOverride>
+                            <autoDeclOverride>F</autoDeclOverride>
+                            <wordRuleOverride>F</wordRuleOverride>
+                        </word>
+                    </lexicon>
+                </dictionary>
+                """,
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <dictionary>
+                    <PolyGlotVer>3.6</PolyGlotVer>
+                    <lexicon>
+                        <word>
+                            <wordId>2</wordId>
+                            <pronunciation/>
+                            <definition/>
+                            <wordProcOverride>F</wordProcOverride>
+                            <autoDeclOverride>F</autoDeclOverride>
+                            <wordRuleOverride>F</wordRuleOverride>
+                        </word>
+                    </lexicon>
+                </dictionary>
+                """
+            )
         );
     }
 }

--- a/src/test/java/org/darisadesigns/polyglotlina/XMLRecoveryToolTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/XMLRecoveryToolTest.java
@@ -74,49 +74,49 @@ public class XMLRecoveryToolTest {
                             <wordId>2</wordId>
                             <pronunciation/>
                             <definition>definition
-                            <wordProcOverride>F</wordProcOverride>
+                            </definition><wordProcOverride>F</wordProcOverride>
                             <autoDeclOverride>F</autoDeclOverride>
                             <wordRuleOverride>F</wordRuleOverride>
-                        </definition></word>
+                        </word>
                     </lexicon>
                 </dictionary>
                 """
             ),
-            Arguments.of(
-                "Missing definition open tag",
-                """
-                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-                <dictionary>
-                    <PolyGlotVer>3.6</PolyGlotVer>
-                    <lexicon>
-                        <word>
-                            <wordId>2</wordId>
-                            <pronunciation/>
-                            definition</definition>
-                            <wordProcOverride>F</wordProcOverride>
-                            <autoDeclOverride>F</autoDeclOverride>
-                            <wordRuleOverride>F</wordRuleOverride>
-                        </word>
-                    </lexicon>
-                </dictionary>
-                """,
-                """
-                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-                <dictionary>
-                    <PolyGlotVer>3.6</PolyGlotVer>
-                    <lexicon>
-                        <word>
-                            <wordId>2</wordId>
-                            <pronunciation/>
-                            definition
-                            <wordProcOverride>F</wordProcOverride>
-                            <autoDeclOverride>F</autoDeclOverride>
-                            <wordRuleOverride>F</wordRuleOverride>
-                        </word>
-                    </lexicon>
-                </dictionary>
-                """
-            )
+             Arguments.of(
+                 "Missing definition open tag",
+                 """
+                 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                 <dictionary>
+                     <PolyGlotVer>3.6</PolyGlotVer>
+                     <lexicon>
+                         <word>
+                             <wordId>2</wordId>
+                             <pronunciation/>
+                             definition</definition>
+                             <wordProcOverride>F</wordProcOverride>
+                             <autoDeclOverride>F</autoDeclOverride>
+                             <wordRuleOverride>F</wordRuleOverride>
+                         </word>
+                     </lexicon>
+                 </dictionary>
+                 """,
+                 """
+                 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                 <dictionary>
+                     <PolyGlotVer>3.6</PolyGlotVer>
+                     <lexicon>
+                         <word>
+                             <wordId>2</wordId>
+                             <pronunciation/>
+                             definition
+                             <wordProcOverride>F</wordProcOverride>
+                             <autoDeclOverride>F</autoDeclOverride>
+                             <wordRuleOverride>F</wordRuleOverride>
+                         </word>
+                     </lexicon>
+                 </dictionary>
+                 """
+             )
         );
     }
 }


### PR DESCRIPTION
XML recovery was adding closing tag after other tags which made the result also be corrupted.  
As well, opening tags were not being added, instead closing tags were being removed.  

Examples of these scenarios can be found in `XMLRecoveryToolTest`.  