### PR TITLE
Refactor Working Directory to OS-specific locations

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -312,7 +312,7 @@ def distLinux():
                '--name "PolyGlot" ' +
                '--license-file LICENSE.TXT ' +
                '--runtime-image build/image')
-    if os.system('command -v rpm &> /dev/null') == 0:
+    if os.system('command -v rpm') == 0:
         print('detected rpm')
         command = command + ' --linux-rpm-license-type MIT '
     os.system(command)

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/CustomControls/PGrammarPane.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/CustomControls/PGrammarPane.java
@@ -78,7 +78,7 @@ public class PGrammarPane extends JTextPane {
         insertImage.addActionListener((ActionEvent ae) -> {
             try {
                 ImageNode image = DesktopIOHandler.getInstance()
-                        .openNewImage((Window) parentPane.getTopLevelAncestor(), core.getWorkingDirectory(), core);
+                        .openNewImage((Window) parentPane.getTopLevelAncestor(), core.getStateDirectory().toFile(), core);
                 if (image != null) {
                     // null node means user cancelled process
                     addImage(image);

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/CustomControls/PTextPane.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/CustomControls/PTextPane.java
@@ -187,7 +187,7 @@ public final class PTextPane extends JTextPane implements CoreUpdateSubscription
         insertImage.addActionListener((ActionEvent ae) -> {
             try {
                 ImageNode image = DesktopIOHandler.getInstance()
-                        .openNewImage((Window)parentPane.getTopLevelAncestor(), core.getWorkingDirectory(), core);
+                        .openNewImage((Window)parentPane.getTopLevelAncestor(), core.getStateDirectory().toFile(), core);
                 if (image != null) {
                     // null node means user cancelled process
                     addImage(image);

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopHelpHandler.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopHelpHandler.java
@@ -55,7 +55,7 @@ public class DesktopHelpHandler implements HelpHandler {
 
     @Override
     public void openHelpLocal() throws IOException {
-        File readmeDir = DesktopIOHandler.getInstance().unzipResourceToTempLocation(PGTUtil.HELP_FILE_ARCHIVE_LOCATION);
+        File readmeDir = DesktopIOHandler.getInstance().unzipResourceToSystemTempLocation(PGTUtil.HELP_FILE_ARCHIVE_LOCATION);
         File readmeFile = new File(readmeDir.getAbsolutePath() + File.separator + PGTUtil.HELP_FILE_NAME);
 
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopIOHandler.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopIOHandler.java
@@ -131,6 +131,7 @@ public final class DesktopIOHandler implements IOHandler {
     public File createTmpFileWithContents(String contents, String extension) throws IOException {
         File ret = File.createTempFile("POLYGLOT", extension,
             PGTUtil.getTempDirectory().toFile());
+        ret.deleteOnExit();
 
         try (Writer out = new BufferedWriter(new OutputStreamWriter(
                 new FileOutputStream(ret), StandardCharsets.UTF_8))) {
@@ -147,6 +148,7 @@ public final class DesktopIOHandler implements IOHandler {
     public File createTmpFileFromImageBytes(byte[] imageBytes, String fileName) throws IOException {
         File tmpFile = File.createTempFile(fileName, ".png",
             PGTUtil.getTempDirectory().toFile());
+        tmpFile.deleteOnExit();
         ByteArrayInputStream stream = new ByteArrayInputStream(imageBytes);
         BufferedImage img = ImageIO.read(stream);
         ImageIO.write(img, "PNG",

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopIOHandler.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopIOHandler.java
@@ -1401,6 +1401,22 @@ public final class DesktopIOHandler implements IOHandler {
     }
 
     /**
+     * This exists so that the help readme is put in a path
+     * that doesn't contain hidden files/folders.
+     * 
+     * Snap applications (e.g. firefox) are not allowed to
+     * access files in these locations. (๑•̀ᗝ•́)૭
+     * @param resourceLocation
+     * @return
+     * @throws IOException
+     */
+    public File unzipResourceToSystemTempLocation(String resourceLocation) throws IOException {
+        Path systemTmp = Files.createTempDirectory(PGTUtil.DISPLAY_NAME);
+        unzipResourceToDir(resourceLocation, systemTmp);
+        return systemTmp.toFile();
+    }
+
+    /**
      * Unzips an internal resource to a targeted path.
      *
      * @param internalPath Path to internal zipped resource

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopOSHandler.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopOSHandler.java
@@ -20,8 +20,11 @@
 package org.darisadesigns.polyglotlina.Desktop;
 
 import java.awt.Desktop;
+import java.awt.geom.Path2D;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -51,12 +54,19 @@ public class DesktopOSHandler extends OSHandler {
     }
     
     @Override
-    public File getWorkingDirectory() {
+    public Path getConfigDirectory() {
         if (overrideProgramPath != null && !overrideProgramPath.trim().isEmpty()) {
-            return new File(overrideProgramPath);
+            return Paths.get(overrideProgramPath);
         }
-        
-        return PGTUtil.getDefaultDirectory();
+        return PGTUtil.getConfigDirectory();
+    }
+
+    @Override
+    public Path getStateDirectory() {
+        if (overrideProgramPath != null && !overrideProgramPath.trim().isEmpty()) {
+            return Paths.get(overrideProgramPath);
+        }
+        return PGTUtil.getStateDirectory();
     }
     
     @Override

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopPFontHandler.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopPFontHandler.java
@@ -47,7 +47,8 @@ import org.darisadesigns.polyglotlina.DictCore;
 public class DesktopPFontHandler extends org.darisadesigns.polyglotlina.PFontHandler {
 
     public static void setFontFromIstream(InputStream is, boolean isConFont, DictCore core) throws IOException, FontFormatException {
-        var tempFile = File.createTempFile("stream2file", ".tmp");
+        var tempFile = File.createTempFile("stream2file", ".tmp",
+            PGTUtil.getTempDirectory().toFile());
         tempFile.deleteOnExit();
         
         // Java only respects ligatures when loading fonts SPECIFICALLY from files, hence the tmp file

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/ManagersCollections/DesktopOptionsManager.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/ManagersCollections/DesktopOptionsManager.java
@@ -22,6 +22,7 @@ package org.darisadesigns.polyglotlina.Desktop.ManagersCollections;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -49,7 +50,7 @@ public class DesktopOptionsManager {
     private int msBetweenSaves;
     private double uiScale = 2.0;
     private int webServicePort = 8080;
-    private String webServiceTargetFolder;
+    private Path webServiceTargetFolder;
     private int webServiceMasterTokenCapacity = 100;
     private int webServiceMasterTokenRefill = 15;
     private int webServiceindividualTokenCapacity = 10;
@@ -75,7 +76,7 @@ public class DesktopOptionsManager {
         msBetweenSaves = PGTUtil.DEFAULT_MS_BETWEEN_AUTO_SAVES;
         java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(PGTUtil.MENU_FONT);
         menuFontFX = javafx.scene.text.Font.font(PGTUtil.MENU_FONT.getFamily(), PGTUtil.DEFAULT_FONT_SIZE);
-        webServiceTargetFolder = PGTUtil.getDefaultDirectory() + File.separator + "WebService";
+        webServiceTargetFolder = PGTUtil.getStateDirectory().resolve("WebService");
     }
     
     public DesktopOptionsManager(DictCore _core) {
@@ -103,7 +104,7 @@ public class DesktopOptionsManager {
         uiScale = 2;
         gptApiKey = "";
         setWebServicePort(8080);
-        setWebServiceTargetFolder(PGTUtil.getDefaultDirectory() + File.separator + "WebService");
+        setWebServiceTargetFolder(PGTUtil.getStateDirectory().resolve("WebService"));
         pdfPrintOrth = true;
         pdfPrintGloss = true;
         pdfPrintLocalLang = true;
@@ -124,7 +125,7 @@ public class DesktopOptionsManager {
         return webServicePort;
     }
     
-    public String getWebServiceTargetFolder() {
+    public Path getWebServiceTargetFolder() {
         return webServiceTargetFolder;
     }
     
@@ -132,7 +133,7 @@ public class DesktopOptionsManager {
         this.webServicePort = webServicePort;
     }
 
-    public void setWebServiceTargetFolder(String webServiceTargetFolder) {
+    public void setWebServiceTargetFolder(Path webServiceTargetFolder) {
         this.webServiceTargetFolder = webServiceTargetFolder;
     }
 

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/NonModularBridge.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/NonModularBridge.java
@@ -81,8 +81,10 @@ public final class NonModularBridge {
         
         File bridge = NonModularBridge.getNonModularBridgeLocation();
         File tmpLangFile = createTmpLangFile(core);
-        File tmpConFontFile = File.createTempFile("PolyGlotConFont", ".ttf", core.getWorkingDirectory());
-        File tmpLocalFontFile = File.createTempFile("PolyGlotLocalFont", ".ttf", core.getWorkingDirectory());
+        File tmpConFontFile = File.createTempFile("PolyGlotConFont", ".ttf",
+            PGTUtil.getTempDirectory().toFile());
+        File tmpLocalFontFile = File.createTempFile("PolyGlotLocalFont", ".ttf",
+            PGTUtil.getTempDirectory().toFile());
         tmpConFontFile.deleteOnExit();
         tmpLocalFontFile.deleteOnExit();
         
@@ -179,7 +181,8 @@ public final class NonModularBridge {
             throws IOException {
         
         File bridge = NonModularBridge.getNonModularBridgeLocation();
-        File tmpTarget = File.createTempFile("PolyGlotTmp", ".csv");
+        File tmpTarget = File.createTempFile("PolyGlotTmp", ".csv",
+            PGTUtil.getTempDirectory().toFile());
         
         String[] command = {
             getJavaExecutablePath(),
@@ -253,7 +256,8 @@ public final class NonModularBridge {
     }
     
     private static File createTmpLangFile(DictCore core) throws IOException {
-        File ret = File.createTempFile("PolyGlot", "LangFile");
+        File ret = File.createTempFile("PolyGlot", "LangFile",
+            PGTUtil.getTempDirectory().toFile());
         
         try {
             core.writeFile(ret.getAbsolutePath(), false, true);

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/NonModularBridge.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/NonModularBridge.java
@@ -183,6 +183,7 @@ public final class NonModularBridge {
         File bridge = NonModularBridge.getNonModularBridgeLocation();
         File tmpTarget = File.createTempFile("PolyGlotTmp", ".csv",
             PGTUtil.getTempDirectory().toFile());
+        tmpTarget.deleteOnExit();
         
         String[] command = {
             getJavaExecutablePath(),
@@ -258,6 +259,7 @@ public final class NonModularBridge {
     private static File createTmpLangFile(DictCore core) throws IOException {
         File ret = File.createTempFile("PolyGlot", "LangFile",
             PGTUtil.getTempDirectory().toFile());
+        ret.deleteOnExit();
         
         try {
             core.writeFile(ret.getAbsolutePath(), false, true);

--- a/src/main/java/org/darisadesigns/polyglotlina/DictCore.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/DictCore.java
@@ -20,6 +20,7 @@
 package org.darisadesigns.polyglotlina;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.time.Instant;
@@ -450,7 +451,7 @@ public class DictCore {
                     _fileName,
                     doc,
                     this,
-                    this.getWorkingDirectory(),
+                    this.getConfigDirectory().toFile(),
                     newSaveTime,
                     writeToReversionMgr,
                     forceClean
@@ -629,8 +630,12 @@ public class DictCore {
         return lastSaveTime;
     }
 
-    public File getWorkingDirectory() {
-        return this.osHandler.getWorkingDirectory();
+    public Path getConfigDirectory() {
+        return this.osHandler.getConfigDirectory();
+    }
+
+    public Path getStateDirectory() {
+        return this.osHandler.getStateDirectory();
     }
 
     public void setCurFileName(String _curFileName) {

--- a/src/main/java/org/darisadesigns/polyglotlina/IOHandler.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/IOHandler.java
@@ -90,7 +90,7 @@ public interface IOHandler {
      *
      * @param workingDirectory
      */
-    void deleteIni(String workingDirectory);
+    void deleteIni(Path workingDirectory);
 
     /**
      * Tests whether or not a file is a zip archive
@@ -253,7 +253,7 @@ public interface IOHandler {
      */
     void writeErrorLog(Throwable exception, String comment);
 
-    File getErrorLogFile();
+    File getErrorLogFile() throws IOException;
 
     String getErrorLog() throws IOException;
 

--- a/src/main/java/org/darisadesigns/polyglotlina/OSHandler.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/OSHandler.java
@@ -19,7 +19,7 @@
  */
 package org.darisadesigns.polyglotlina;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import org.darisadesigns.polyglotlina.Nodes.LexiconProblemNode;
 
@@ -45,8 +45,10 @@ public abstract class OSHandler {
         helpHandler =_helpHandler;
         fontHandler = _fontHandler;
     }
-    
-    public abstract File getWorkingDirectory();
+
+    public abstract Path getConfigDirectory();
+
+    public abstract Path getStateDirectory();
     
     public abstract void openLanguageProblemDisplay(List<LexiconProblemNode> problems, DictCore _core);
     

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrAbout.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrAbout.java
@@ -44,12 +44,15 @@ public class ScrAbout extends PDialog {
         super.getRootPane().getContentPane().setBackground(Color.white);
 
         txtAbout.setText("PolyGlot ver. " + PGTUtil.getDisplayVersion() + "\n\nPolyGlot is "
-                + "copyright Draque Thompson 2014-" + Calendar.getInstance().get(Calendar.YEAR)
-                + ". It is licensed under the MIT Licence, so it is free "
-                + "to distribute. Please don't sell this or call it your own, but feel free to "
-                + "use and modify the code found on the open source repository for PolyGlot.\n\n"
-                + "HomePage: http://draquet.github.io/PolyGlot/\nGitHub Repository: "
-                + "https://github.com/DraqueT/PolyGlot\n\nBuild Date: " + PGTUtil.BUILD_DATE_TIME);
+            + "copyright Draque Thompson 2014-" + Calendar.getInstance().get(Calendar.YEAR)
+            + ". It is licensed under the MIT Licence, so it is free "
+            + "to distribute. Please don't sell this or call it your own, but feel free to "
+            + "use and modify the code found on the open source repository for PolyGlot.\n\n"
+            + "HomePage: http://draquet.github.io/PolyGlot/\nGitHub Repository: "
+            + "https://github.com/DraqueT/PolyGlot\n\nBuild Date: " + PGTUtil.BUILD_DATE_TIME
+            + "\n\nConfig Directory: " + PGTUtil.getConfigDirectory().toString()
+            + "\nTemp Directory: " + PGTUtil.getTempDirectory().toString()
+            + "\nData Directory: " + PGTUtil.getStateDirectory().toString());
     }
     
     @Override

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrExcelImport.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrExcelImport.java
@@ -87,7 +87,6 @@ public class ScrExcelImport extends PDialog {
 
     private void browseFile() {
         JFileChooser chooser = new JFileChooser();
-        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         FileNameExtensionFilter filter = new FileNameExtensionFilter("Excel/CSV Documents", "xls", "xlsx", "xlsm", "csv", "txt", "tsv");
         chooser.setFileFilter(filter);
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrExcelImport.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrExcelImport.java
@@ -87,7 +87,7 @@ public class ScrExcelImport extends PDialog {
 
     private void browseFile() {
         JFileChooser chooser = new JFileChooser();
-        chooser.setCurrentDirectory(core.getWorkingDirectory());
+        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         FileNameExtensionFilter filter = new FileNameExtensionFilter("Excel/CSV Documents", "xls", "xlsx", "xlsm", "csv", "txt", "tsv");
         chooser.setFileFilter(filter);
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrFontImportDialog.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrFontImportDialog.java
@@ -116,7 +116,7 @@ public final class ScrFontImportDialog extends PDialog {
 
         chooser.setDialogTitle("Select Font File");
         chooser.setFileFilter(filter);
-        chooser.setCurrentDirectory(core.getWorkingDirectory());
+        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         chooser.setApproveButtonText("Open");
 
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrFontImportDialog.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrFontImportDialog.java
@@ -116,7 +116,6 @@ public final class ScrFontImportDialog extends PDialog {
 
         chooser.setDialogTitle("Select Font File");
         chooser.setFileFilter(filter);
-        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         chooser.setApproveButtonText("Open");
 
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLogoDetails.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLogoDetails.java
@@ -906,7 +906,6 @@ public class ScrLogoDetails extends PFrame {
                 "BMP", "bmp", "jpeg", "wbmp", "gif", "GIF", "png", "JPG", "jpg", "WBMP", "JPEG", "PNG");
         chooser.setFileFilter(filter);
         String fileName;
-        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
 
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
             fileName = chooser.getSelectedFile().getAbsolutePath();

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLogoDetails.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLogoDetails.java
@@ -906,7 +906,7 @@ public class ScrLogoDetails extends PFrame {
                 "BMP", "bmp", "jpeg", "wbmp", "gif", "GIF", "png", "JPG", "jpg", "WBMP", "JPEG", "PNG");
         chooser.setFileFilter(filter);
         String fileName;
-        chooser.setCurrentDirectory(core.getWorkingDirectory());
+        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
 
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
             fileName = chooser.getSelectedFile().getAbsolutePath();

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrMainMenu.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrMainMenu.java
@@ -286,7 +286,13 @@ public final class ScrMainMenu extends PFrame {
 
             if (files != null) {
                 for (File exampleLang : files) {
-                    final String title = exampleLang.getName().replace("_", " ").replace(".pgd", "");
+                    // check that the file extension is pgd
+                    String fileName = exampleLang.getName();
+                    if (!fileName.endsWith("pgd")) {
+                        continue;
+                    }
+
+                    final String title = fileName.replace("_", " ").replace(".pgd", "");
                     final String location = exampleLang.getAbsolutePath();
 
                     JMenuItem mnuExample = new JMenuItem(title);
@@ -2136,7 +2142,7 @@ public final class ScrMainMenu extends PFrame {
         mnuHelp.add(mnuChkUpdate);
 
         mnuExLex.setText("Example Languages");
-        mnuExLex.setToolTipText("Languages with exmples to copy from");
+        mnuExLex.setToolTipText("Languages with examples to copy from");
         mnuHelp.add(mnuExLex);
 
         jMenuItem4.setText("Create Bug Report");

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrMainMenu.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrMainMenu.java
@@ -848,7 +848,7 @@ public final class ScrMainMenu extends PFrame {
     }
 
     private void openHelp() throws IOException {
-        File readmeDir = DesktopIOHandler.getInstance().unzipResourceToTempLocation(PGTUtil.HELP_FILE_ARCHIVE_LOCATION);
+        File readmeDir = DesktopIOHandler.getInstance().unzipResourceToSystemTempLocation(PGTUtil.HELP_FILE_ARCHIVE_LOCATION);
         File readmeFile = new File(readmeDir.getAbsolutePath() + File.separator + PGTUtil.HELP_FILE_NAME);
 
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrMainMenu.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrMainMenu.java
@@ -606,7 +606,7 @@ public final class ScrMainMenu extends PFrame {
         chooser.setFileFilter(filter);
         chooser.setApproveButtonText("Save");
         if (curFileName.isEmpty()) {
-            chooser.setCurrentDirectory(core.getWorkingDirectory());
+            chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         } else {
             chooser.setCurrentDirectory(DesktopIOHandler.getInstance().getDirectoryFromPath(curFileName));
             chooser.setSelectedFile(DesktopIOHandler.getInstance().getFileFromPath(curFileName));
@@ -691,7 +691,7 @@ public final class ScrMainMenu extends PFrame {
         chooser.setFileFilter(filter);
         String fileName;
         if (curFileName.isEmpty()) {
-            chooser.setCurrentDirectory(core.getWorkingDirectory());
+            chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         } else {
             chooser.setCurrentDirectory(DesktopIOHandler.getInstance().getDirectoryFromPath(curFileName));
         }
@@ -756,7 +756,7 @@ public final class ScrMainMenu extends PFrame {
         FileNameExtensionFilter filter = new FileNameExtensionFilter("Excel Files", "xls");
         chooser.setFileFilter(filter);
         chooser.setApproveButtonText("Save");
-        chooser.setCurrentDirectory(core.getWorkingDirectory());
+        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
 
         String fileName = core.getCurFileName().replaceAll("\\.pgd", ".xls");
         chooser.setSelectedFile(new File(fileName));
@@ -808,7 +808,7 @@ public final class ScrMainMenu extends PFrame {
 
         chooser.setDialogTitle("Export Font");
         chooser.setFileFilter(filter);
-        chooser.setCurrentDirectory(core.getWorkingDirectory());
+        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         chooser.setApproveButtonText("Save");
         chooser.setSelectedFile(new File(fileName));
 
@@ -1420,7 +1420,7 @@ public final class ScrMainMenu extends PFrame {
         chooser.setFileFilter(filter);
         chooser.setApproveButtonText("Save");
         if (curFileName.isEmpty() || !curFileName.contains(".pgd")) {
-            chooser.setCurrentDirectory(core.getWorkingDirectory());
+            chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         } else {
             String suggestedDicFile = curFileName.replaceAll("\\.pgd", ".dic");
             chooser.setCurrentDirectory(DesktopIOHandler.getInstance().getDirectoryFromPath(curFileName));
@@ -1475,7 +1475,7 @@ public final class ScrMainMenu extends PFrame {
         chooser.setFileFilter(filter);
 
         if (curFileName.isEmpty()) {
-            chooser.setCurrentDirectory(core.getWorkingDirectory());
+            chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         } else {
             chooser.setCurrentDirectory(DesktopIOHandler.getInstance().getDirectoryFromPath(curFileName));
         }
@@ -1507,7 +1507,7 @@ public final class ScrMainMenu extends PFrame {
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 
         if (curFileName.isEmpty()) {
-            chooser.setCurrentDirectory(core.getWorkingDirectory());
+            chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         } else {
             chooser.setCurrentDirectory(DesktopIOHandler.getInstance().getDirectoryFromPath(curFileName));
         }

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrMainMenu.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrMainMenu.java
@@ -605,9 +605,7 @@ public final class ScrMainMenu extends PFrame {
         chooser.setDialogTitle("Save Language");
         chooser.setFileFilter(filter);
         chooser.setApproveButtonText("Save");
-        if (curFileName.isEmpty()) {
-            chooser.setCurrentDirectory(core.getStateDirectory().toFile());
-        } else {
+        if (!curFileName.isEmpty()) {
             chooser.setCurrentDirectory(DesktopIOHandler.getInstance().getDirectoryFromPath(curFileName));
             chooser.setSelectedFile(DesktopIOHandler.getInstance().getFileFromPath(curFileName));
         }
@@ -690,9 +688,7 @@ public final class ScrMainMenu extends PFrame {
         FileNameExtensionFilter filter = new FileNameExtensionFilter("PolyGlot Languages", "pgd");
         chooser.setFileFilter(filter);
         String fileName;
-        if (curFileName.isEmpty()) {
-            chooser.setCurrentDirectory(core.getStateDirectory().toFile());
-        } else {
+        if (!curFileName.isEmpty()) {
             chooser.setCurrentDirectory(DesktopIOHandler.getInstance().getDirectoryFromPath(curFileName));
         }
 
@@ -756,7 +752,6 @@ public final class ScrMainMenu extends PFrame {
         FileNameExtensionFilter filter = new FileNameExtensionFilter("Excel Files", "xls");
         chooser.setFileFilter(filter);
         chooser.setApproveButtonText("Save");
-        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
 
         String fileName = core.getCurFileName().replaceAll("\\.pgd", ".xls");
         chooser.setSelectedFile(new File(fileName));
@@ -808,7 +803,6 @@ public final class ScrMainMenu extends PFrame {
 
         chooser.setDialogTitle("Export Font");
         chooser.setFileFilter(filter);
-        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         chooser.setApproveButtonText("Save");
         chooser.setSelectedFile(new File(fileName));
 
@@ -1419,9 +1413,7 @@ public final class ScrMainMenu extends PFrame {
         chooser.setDialogTitle("Export Custom Dictionary File");
         chooser.setFileFilter(filter);
         chooser.setApproveButtonText("Save");
-        if (curFileName.isEmpty() || !curFileName.contains(".pgd")) {
-            chooser.setCurrentDirectory(core.getStateDirectory().toFile());
-        } else {
+        if (!curFileName.isEmpty() && curFileName.contains(".pgd")) {
             String suggestedDicFile = curFileName.replaceAll("\\.pgd", ".dic");
             chooser.setCurrentDirectory(DesktopIOHandler.getInstance().getDirectoryFromPath(curFileName));
             chooser.setSelectedFile(DesktopIOHandler.getInstance().getFileFromPath(suggestedDicFile));
@@ -1474,9 +1466,7 @@ public final class ScrMainMenu extends PFrame {
         FileNameExtensionFilter filter = new FileNameExtensionFilter("PolyGlot Languages", "pgd");
         chooser.setFileFilter(filter);
 
-        if (curFileName.isEmpty()) {
-            chooser.setCurrentDirectory(core.getStateDirectory().toFile());
-        } else {
+        if (!curFileName.isEmpty()) {
             chooser.setCurrentDirectory(DesktopIOHandler.getInstance().getDirectoryFromPath(curFileName));
         }
 
@@ -1506,9 +1496,7 @@ public final class ScrMainMenu extends PFrame {
         chooser.setDialogTitle("Pack Language Dirctory to PGD File");
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 
-        if (curFileName.isEmpty()) {
-            chooser.setCurrentDirectory(core.getStateDirectory().toFile());
-        } else {
+        if (!curFileName.isEmpty()) {
             chooser.setCurrentDirectory(DesktopIOHandler.getInstance().getDirectoryFromPath(curFileName));
         }
 

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrPrintToPDF.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrPrintToPDF.java
@@ -510,7 +510,7 @@ public class ScrPrintToPDF extends PDialog {
         String fileName = core.getCurFileName().replaceAll(".pgd", ".pdf");
         chooser.setFileFilter(filter);
         chooser.setApproveButtonText("Save");
-        chooser.setCurrentDirectory(core.getWorkingDirectory());
+        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         chooser.setSelectedFile(new File(fileName));
 
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
@@ -594,7 +594,7 @@ public class ScrPrintToPDF extends PDialog {
                 "BMP", "bmp", "jpeg", "wbmp", "gif", "GIF", "png", "JPG", "jpg", "WBMP", "JPEG", "PNG");
         chooser.setFileFilter(filter);
         String fileName;
-        chooser.setCurrentDirectory(core.getWorkingDirectory());
+        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
 
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
             fileName = chooser.getSelectedFile().getAbsolutePath();

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrPrintToPDF.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrPrintToPDF.java
@@ -510,7 +510,6 @@ public class ScrPrintToPDF extends PDialog {
         String fileName = core.getCurFileName().replaceAll(".pgd", ".pdf");
         chooser.setFileFilter(filter);
         chooser.setApproveButtonText("Save");
-        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
         chooser.setSelectedFile(new File(fileName));
 
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
@@ -594,7 +593,6 @@ public class ScrPrintToPDF extends PDialog {
                 "BMP", "bmp", "jpeg", "wbmp", "gif", "GIF", "png", "JPG", "jpg", "WBMP", "JPEG", "PNG");
         chooser.setFileFilter(filter);
         String fileName;
-        chooser.setCurrentDirectory(core.getStateDirectory().toFile());
 
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
             fileName = chooser.getSelectedFile().getAbsolutePath();

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrWebService.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrWebService.java
@@ -124,7 +124,7 @@ public class ScrWebService extends PFrame {
             txtITokenCapacity.setText("" + optMan.getWebServiceIndividualTokenCapacity());
             txtITokenRefil.setText("" + optMan.getWebServiceIndividualTokenRefil());
             chkActivateWebservice.setSelected(PolyGlot.isWebServiceRunning());
-            txtServedFolder.setText(optMan.getWebServiceTargetFolder());
+            txtServedFolder.setText(optMan.getWebServiceTargetFolder().toString());
         });
     }
     

--- a/src/main/java/org/darisadesigns/polyglotlina/Webservice/WebService.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Webservice/WebService.java
@@ -84,7 +84,7 @@ public class WebService {
     public WebService(PolyGlot _polyGlot) throws Exception {
         rateLimiterPerAddress = new ConcurrentHashMap<>();
         polyGlot = _polyGlot;
-        logFile = new File(polyGlot.getWorkingDirectory() + File.separator + PGTUtil.WEB_SERVICE_LOG_FILE);
+        logFile = PGTUtil.getStateDirectory().resolve(PGTUtil.WEB_SERVICE_LOG_FILE).toFile();
         
         // master rate limiter gives some basic DDOS protection
         masterRateLimiter = new TokenBucketRateLimiter(
@@ -262,7 +262,7 @@ public class WebService {
      * PWebServerException
      */
     private File getLanguageFile(String fileName) throws PWebServerException {
-        var file = new File(polyGlot.getOptionsManager().getWebServiceTargetFolder() + File.separator + fileName);
+        var file = polyGlot.getOptionsManager().getWebServiceTargetFolder().resolve(fileName).toFile();
 
         if (file.exists()) {
             return file;
@@ -584,7 +584,7 @@ public class WebService {
     }
 
     private void populateServedFiles() throws Exception {
-        File servedDirectory = new File(polyGlot.getOptionsManager().getWebServiceTargetFolder());
+        File servedDirectory = polyGlot.getOptionsManager().getWebServiceTargetFolder().toFile();
         pgdFiles = new HashMap<>();
 
         if (!servedDirectory.exists()) {

--- a/src/test/java/org/darisadesigns/polyglotlina/Desktop/ManagersCollections/DesktopOptionsManagerTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/Desktop/ManagersCollections/DesktopOptionsManagerTest.java
@@ -23,6 +23,7 @@ import TestResources.DummyCore;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.io.File;
+import java.nio.file.Paths;
 import org.darisadesigns.polyglotlina.Desktop.DesktopIOHandler;
 import org.darisadesigns.polyglotlina.Desktop.PolyGlot;
 import org.darisadesigns.polyglotlina.DictCore;
@@ -93,14 +94,14 @@ public class DesktopOptionsManagerTest {
             opt.setZompistUseConlangFont(useConFontZompist);
 
             // save values to disk...
-            DesktopIOHandler.getInstance().writeOptionsIni(core.getWorkingDirectory().getAbsolutePath(), opt);
+            DesktopIOHandler.getInstance().writeOptionsIni(core.getConfigDirectory(), opt);
 
             // create new core to load saved values into...
             core = DummyCore.newCore();
             opt = PolyGlot.getPolyGlot().getOptionsManager();
             
-            // relaod saved values...
-            DesktopIOHandler.getInstance().loadOptionsIni(core.getWorkingDirectory().getAbsolutePath(), opt);
+            // reload saved values...
+            DesktopIOHandler.getInstance().loadOptionsIni(core.getConfigDirectory(), opt);
             
             assertEquals(animatedExpected, opt.isAnimateWindows());
             assertEquals(reversionCountExpected, opt.getMaxReversionCount());
@@ -143,7 +144,7 @@ public class DesktopOptionsManagerTest {
             DesktopOptionsManager opt = PolyGlot.getPolyGlot().getOptionsManager();
             
             try {
-                DesktopIOHandler.getInstance().loadOptionsIni(core.getWorkingDirectory().getAbsolutePath() + File.separator + "iniCorrupted", opt);
+                DesktopIOHandler.getInstance().loadOptionsIni(core.getConfigDirectory().resolve("iniCorrupted"), opt);
             } catch (DesktopOptionsManagerException e) {
                 expectedException = true;
             }

--- a/src/test/java/org/darisadesigns/polyglotlina/DictCoreTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/DictCoreTest.java
@@ -104,7 +104,8 @@ public class DictCoreTest {
         try {
             DictCore origin = DummyCore.newCore();
             DictCore target = DummyCore.newCore();
-            Path targetPath = Files.createTempFile("POLYGLOT", "pgt");
+            Path targetPath = Files.createTempFile(PGTUtil.getTempDirectory(),
+                "POLYGLOT", "pgt");
             
             origin.readFile(PGTUtil.TESTRESOURCES + "test_equality.pgd");
             origin.writeFile(targetPath.toString(), false, false);
@@ -125,7 +126,8 @@ public class DictCoreTest {
         try {
             DictCore origin = DummyCore.newCore();
             DictCore target = DummyCore.newCore();
-            Path targetPath = Files.createTempFile("POLYGLOT", "pgt");
+            Path targetPath = Files.createTempFile(PGTUtil.getTempDirectory(),
+                "POLYGLOT", "pgt");
             
             origin.readFile(PGTUtil.TESTRESOURCES + "test_equality.pgd");
             origin.writeFile(targetPath.toString(), false, false);

--- a/src/test/java/org/darisadesigns/polyglotlina/DictCoreTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/DictCoreTest.java
@@ -104,12 +104,13 @@ public class DictCoreTest {
         try {
             DictCore origin = DummyCore.newCore();
             DictCore target = DummyCore.newCore();
-            Path targetPath = Files.createTempFile(PGTUtil.getTempDirectory(),
-                "POLYGLOT", "pgt");
+            File targetFile = File.createTempFile("POLYGLOT", "pgt",
+                PGTUtil.getTempDirectory().toFile());
+            targetFile.deleteOnExit();
             
             origin.readFile(PGTUtil.TESTRESOURCES + "test_equality.pgd");
-            origin.writeFile(targetPath.toString(), false, false);
-            target.readFile(targetPath.toString());
+            origin.writeFile(targetFile.toString(), false, false);
+            target.readFile(targetFile.toString());
             
             assertEquals(origin, target, "DictCoreTest.testIsLanguageEmptyNoPOS:F");
         } catch (IOException | IllegalStateException | ParserConfigurationException | TransformerException e) {
@@ -126,12 +127,13 @@ public class DictCoreTest {
         try {
             DictCore origin = DummyCore.newCore();
             DictCore target = DummyCore.newCore();
-            Path targetPath = Files.createTempFile(PGTUtil.getTempDirectory(),
-                "POLYGLOT", "pgt");
+            File targetFile = File.createTempFile("POLYGLOT", "pgt",
+                PGTUtil.getTempDirectory().toFile());
+            targetFile.deleteOnExit();
             
             origin.readFile(PGTUtil.TESTRESOURCES + "test_equality.pgd");
-            origin.writeFile(targetPath.toString(), false, false);
-            target.readFile(targetPath.toString());
+            origin.writeFile(targetFile.toString(), false, false);
+            target.readFile(targetFile.toString());
             
             assertEquals(origin, target, "DictCoreTest.testIsLanguageEmptyNoPOS:F");
         } catch (IOException | IllegalStateException | ParserConfigurationException | TransformerException e) {

--- a/src/test/java/org/darisadesigns/polyglotlina/IOHandlerTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/IOHandlerTest.java
@@ -58,8 +58,7 @@ public class IOHandlerTest {
         System.out.println("IOHandlerTest.testWriteErrorLogBasic");
         
         DesktopIOHandler.getInstance().writeErrorLog(new Exception("This is a test."));
-        File myLog = new File(PGTUtil.getErrorDirectory().getAbsolutePath() 
-                + File.separator + PGTUtil.ERROR_LOG_FILE);
+        File myLog = PGTUtil.getErrorDirectory().resolve(PGTUtil.ERROR_LOG_FILE).toFile();
         
         assertTrue(myLog.exists());
         

--- a/src/test/java/org/darisadesigns/polyglotlina/Screens/OpenScreensTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/Screens/OpenScreensTest.java
@@ -44,16 +44,16 @@ import org.junit.jupiter.api.Test;
  * @author draque
  */
 public class OpenScreensTest {
-    private final File errors;
+    private File errors;
     private final DictCore core;
     private final boolean headless = GraphicsEnvironment.isHeadless(); // testing this in a headless environment makes no sense
     
     public OpenScreensTest() {
         PGTUtil.enterUITestingMode();
         core = DummyCore.newCore();
-        errors = DesktopIOHandler.getInstance().getErrorLogFile();
         
         try {
+            errors = DesktopIOHandler.getInstance().getErrorLogFile();
             core.readFile(PGTUtil.TESTRESOURCES + "basic_lang.pgd");
 
             if (errors.exists()) {


### PR DESCRIPTION
## Changes
- `getWorkingDirectory` was split into: `getConfigDirectory`, `getStateDirectory`, and `getTempDirectory`
   - in each of the returned directories, a `PolyGlot` folder is created
   - The original functionality of unit tests using `PolyGlot_TEST` instead of `PolyGlot` is kept
   - Unzipping of `readme.zip` is still done in a system temp directory as the designers of snap decided that snap packages should not be able to open files in hidden directories.

| Function | Linux Path | Windows Path | OSX Path |
| --- | --- | --- | --- |
| getConfigDirectory() | $XDG_CONFIG_HOME<br>or ~/.config| %LOCALAPPDATA% | ~/Library/Preferences |
| getStateDirectory() | $XDG_STATE_HOME<br>or ~/.local/cache | %LOCALAPPDATA% | ~/Library/Application Support |
| getTempDirectory() | $XDG_CACHE_HOME<br>or ~/.local/state | %TEMP% | ~/Library/Caches |

- general refactors to use java.nio.file.Path instead of String & File
- updated tests
- `getErrorLogFile` can now throw `IOException`
- Updated the About menu to list the locations of the config, state, and temp directories
- File browser directories were changed to use the default location. Default is user home on linux, my documents on windows. Affects the following
   - excel export
   - font export
   - dic export
   - import lexicon from file
   - pack/unpack language

## Notes
- config is used for `PolyGlot.ini`. state is used for: autosave file, error log, webservice files (in sub-directory called `WebServices`). temp is used for: temp files (csv <-> excel), and unzipping of resource files
   - I would prefer to have files like the help be stored in the state directory, but that would require far more rework of the codebase. I am going to leave that for a future rework
- This brings understanding of the XDG base directory specification into PolyGlot. I tried my best to map these locations to windows & macos while keeping the source code simple. Please correct me if any of this is wrong.
- This is a stepping stone towards distribution as [flatpak](https://docs.flatpak.org/en/latest/conventions.html). This is the primary motivation behind this pr

Draft:
- [x] Add/update help menu to show what paths the app is using
- [x] update for creation of temp files for various things
- [x] manually test excel file opening
- [x] manually test font import file opening
- [x] manually test logo import file opening
- [x] manually test webservice file opening
- [x] manually test print 2 pdf file opening
- [x] run tests on windows
- [x] run tests on macOS

Closes https://github.com/DraqueT/PolyGlot/issues/1349