### PR TITLE
Python 3 version of build_image.py

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -185,7 +185,7 @@ def main(args):
     if (full_build and 'docs' not in skip_steps) or 'docs' in args:
         injectDocs()
     if (full_build and 'build' not in skip_steps) or 'build' in args:
-        build()
+        build(skipTests)
     if (full_build and 'clean' not in skip_steps) or 'clean' in args or 'image' in args:
         clean()
     if (full_build and 'image' not in skip_steps) or 'image' in args:
@@ -196,15 +196,15 @@ def main(args):
     print('Done!')
 
 
-def build():
+def build(skipTests : bool):
     print('Injecting build date/time...')
     injectBuildDate()
     if osString == linString:
-        buildLinux()
+        buildLinux(skipTests)
     elif osString == osxString:
-        buildOsx()
+        buildOsx(skipTests)
     elif osString == winString:
-        buildWin()
+        buildWin(skipTests)
 
 
 def clean():
@@ -240,8 +240,7 @@ def dist():
 #       LINUX FUNCTIONALITY
 ######################################
 
-def buildLinux():
-    global skipTests
+def buildLinux(skipTests : bool):
     print('cleaning/testing/compiling...')
     command = 'mvn clean package'
 
@@ -325,15 +324,14 @@ def distLinux():
         print('failed to locate jpackage output')
 
     if copyDestination != "":
-        copyInstaller(installer_file)
+        copyInstaller(copyDestination, installer_file)
 
 
 ######################################
 #       Mac OS FUNCTIONALITY
 ######################################
 
-def buildOsx():
-    global skipTests
+def buildOsx(skipTests : bool):
     print('cleaning/testing/compiling...')
     command = 'mvn clean package'
 
@@ -458,7 +456,7 @@ def distOsx():
             print('No distribution signing identity specified, dmg installer will not be signed for distribution')
 
         if copyDestination != "":
-            copyInstaller('PolyGlot-' + POLYGLOT_VERSION + '.dmg')
+            copyInstaller(copyDestination, 'PolyGlot-' + POLYGLOT_VERSION + '.dmg')
 
     except Exception as e:
         print('Exception: ' + str(e))
@@ -474,8 +472,7 @@ def distOsx():
 #       WINDOWS FUNCTIONALITY
 ######################################
 
-def buildWin():
-    global skipTests
+def buildWin(skipTests : bool):
     print('cleaning/testing/compiling...')
     command = 'mvn clean package'
 
@@ -549,7 +546,7 @@ def distWin():
     os.system(command)
 
     if copyDestination != "":
-        copyInstaller(package_location)
+        copyInstaller(copyDestination, package_location)
 
 
 # injects current time into file which lives in PolyGlot resources
@@ -675,8 +672,7 @@ def injectDocs():
 
 
 # Copies installer file to final destination and removes error indicator file
-def copyInstaller(source):
-    global copyDestination
+def copyInstaller(copyDestination : str, source : str):
     global macIntelBuild
 
     if path.exists(source):

--- a/build_image.py
+++ b/build_image.py
@@ -30,7 +30,6 @@ linString = 'Linux'
 osxString = 'Darwin'
 winString = 'Windows'
 
-separatorCharacter = '/'
 macIntelBuild = False
 skipTests = False
 
@@ -82,7 +81,6 @@ def main(args):
     global LANG3_VER
     global failFile
     global copyDestination
-    global separatorCharacter
     global macIntelBuild
     global skipTests
 
@@ -91,9 +89,6 @@ def main(args):
         return
 
     skip_steps = []
-
-    if osString == winString:
-        separatorCharacter = '\\'
 
     if '-skipTests' in args or '-skiptests' in args:
         skipTests = True
@@ -156,7 +151,7 @@ def main(args):
         copyDestination = args[command_index + 1]
 
         # failure message file created here, deleted at end of process conditionally upon success
-        failFile = copyDestination + separatorCharacter + osString + "_BUILD_FAILED"
+        failFile = os.path.join(copyDestination, osString + "_BUILD_FAILED")
         open(failFile, 'a').close()
 
         # remove args after consuming
@@ -560,10 +555,7 @@ def distWin():
 # injects current time into file which lives in PolyGlot resources
 def injectBuildDate():
     build_time = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
-    file_path = 'assets/assets/org/DarisaDesigns/buildDate'
-
-    if osString == winString:
-        file_path = file_path.replace('/', '\\')
+    file_path = os.path.join('assets', 'assets', 'org', 'DarisaDesigns', 'buildDate')
 
     f = open(file_path, 'w')
     f.write(build_time)
@@ -578,23 +570,16 @@ def injectBuildDate():
 def getJfxLocation():
     ret = os.path.expanduser('~')
 
-    if osString == winString:
-        ret += '\\.m2\\repository\\org\\openjfx'
-    elif osString == osxString and macIntelBuild:
-        ret += '/.m2/repository/org/openjfx_intel'
-    elif osString == osxString or osString == linString:
-        ret += '/.m2/repository/org/openjfx'
+    if osString == osxString and macIntelBuild:
+        ret = os.path.join(ret, '.m2', 'repository', 'org', 'openjfx_intel')
+    else:
+        ret = os.path.join(ret, '.m2', 'repository', 'org', 'openjfx')
 
     return ret
 
 
 def getRepositoryLocation():
-    ret = os.path.expanduser('~')
-    if osString == winString:
-        ret += '\\.m2\\repository'
-    elif osString == osxString or osString == linString:
-        ret += '/.m2/repository'
-    return ret
+    return os.path.join(os.path.expanduser('~'), '.m2', 'repository')
 
 
 def getDependencyVersionByGroupId(group_id):
@@ -651,13 +636,10 @@ def getBuildNum():
     return ret
 
 
-def updateVersionResource(version_string):
+def updateVersionResource(version_string : str):
     global IS_RELEASE
 
-    if osString == winString:
-        location = 'assets\\assets\\org\\DarisaDesigns\\version'
-    else:
-        location = 'assets/assets/org/DarisaDesigns/version'
+    location = os.path.join('assets', 'assets', 'org', 'DarisaDesigns', 'version')
 
     if path.exists(location):
         os.remove(location)
@@ -675,10 +657,7 @@ def injectDocs():
 
     # readme and resources...
     extension = '.zip'
-    if osString == winString:
-        readme_location = 'assets\\assets\\org\\DarisaDesigns\\readme'
-    else:
-        readme_location = 'assets/assets/org/DarisaDesigns/readme'
+    readme_location = os.path.join('assets', 'assets', 'org', 'DarisaDesigns', 'readme')
 
     if path.exists(readme_location + extension):
         os.remove(readme_location + extension)
@@ -686,12 +665,8 @@ def injectDocs():
     shutil.make_archive(readme_location, 'zip', 'docs')
 
     # example dictionaries
-    if osString == winString:
-        source_location = 'packaging_files\\example_lexicons'
-        dict_location = 'assets\\assets\\org\\DarisaDesigns\\exlex'
-    else:
-        source_location = 'packaging_files/example_lexicons'
-        dict_location = 'assets/assets/org/DarisaDesigns/exlex'
+    source_location = os.path.join('packaging_files', 'example_lexicons')
+    dict_location = os.path.join('assets', 'assets', 'org', 'DarisaDesigns', 'exlex')
 
     if path.exists(source_location + extension):
         os.remove(readme_location + extension)
@@ -718,9 +693,9 @@ def copyInstaller(source):
 
         # release candidates copied to their own location
         if IS_RELEASE:
-            copyDestination = copyDestination + separatorCharacter + 'Release'
+            copyDestination = os.path.join(copyDestination, 'Release')
 
-        destination = copyDestination + separatorCharacter + ins_file
+        destination = os.path.join(destination, ins_file)
         print('Copying installer to ' + destination)
         shutil.copy(source, destination)
 

--- a/build_image.py
+++ b/build_image.py
@@ -1,14 +1,14 @@
-##############################################################################
-#
-#   PolyGlot build script Copyright 2019-2023 Draque Thompson
-#
-#   This script builds PolyGlot into a distributable package on Linux,
-#   OSX, and Windows. Windows does not come with Python installed by default.
-#   This runs on both Python 2.7 and 3.x. 
-#
-#   From: https://github.com/DraqueT/PolyGlot/
-#
-##############################################################################
+#!/usr/bin/python3
+"""
+This script builds PolyGlot into a distributable package on Linux,
+OSX, and Windows.
+"""
+
+__author__      = "Draque Thompson"
+__copyright__   = "2019-2024"
+__license__     = "MIT"
+__maintainer__  = "draquemail@gmail.com"
+__status__      = "Production"
 
 import datetime
 from datetime import date


### PR DESCRIPTION
## Changes
- Replaced argument parsing with the `argparse` module
- Replaced usage of globals with directly passing values into functions
- Introduction of typing
- Usage of `os.path.join` instead of using manual logic for OS-specific paths
- Usage of more typical python metadata, including shebang for *nix
- Consolidated build, image, & clean functions, and used python standard library functions where it made sense

- improves error checking of system commands
- improves checking on arguments passed to `build_image.py`

## Notes
- The `--step` argument, if not provided, makes the tool default to a full build. If provided, it will run that step. Providing it multiple times allows for multiple steps.
- I have dropped the ability to skip a step. It's not a common thing to do, and I think the ability to specify which steps you want to run is good enough? there are only 5 of them
- Drops python 2 support!!
- There is more that I could do, but this PR is already pretty big in terms of LOC and complexity. `os.system` is still used here but it's far less than it used to be

Draft:
- [x] further replacement of globals
- [x] testing testing testing

Closes #1368