### PR TITLE
1011 update release package name

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2014-2023  Draque Thompson
+Copyright 2014-2024  Draque Thompson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/build_image.py
+++ b/build_image.py
@@ -34,20 +34,9 @@ winString = 'Windows'
 
 macIntelBuild = False
 
-###############################
-# LINUX BUILD CONSTANTS
-LIN_INS_NAME = 'PolyGlot-Ins-Lin.deb'
-
-###############################
 # OSX BUILD CONSTANTS
-OSX_INS_NAME = 'PolyGlot-Ins-Osx.dmg'
-OSX_INTEL_INS_NAME = 'PolyGlot-Ins-Osx-intel.dmg'
 SIGN_IDENTITY = ''  # set in main for timing reasons
 DISTRIB_IDENTITY = ''  # set in main for timing reasons
-
-###############################
-# WINDOWS BUILD CONSTANTS
-WIN_INS_NAME = 'PolyGlot-Ins-Win.exe'
 
 ###############################
 # UNIVERSAL BUILD CONSTANTS
@@ -524,32 +513,23 @@ def injectDocs():
 def copyInstaller(copyDestination : str, source : str, IS_RELEASE : bool):
     global macIntelBuild
 
-    if path.exists(source):
-        ins_file = ""
-
-        if osString == winString:
-            ins_file = WIN_INS_NAME
-        elif osString == linString:
-            ins_file = LIN_INS_NAME
-        elif osString == osxString and macIntelBuild:
-            ins_file = OSX_INTEL_INS_NAME
-        elif osString == osxString:
-            ins_file = OSX_INS_NAME
-
-        # release candidates copied to their own location
-        if IS_RELEASE:
-            copyDestination = os.path.join(copyDestination, 'Release')
-
-        destination = os.path.join(destination, ins_file)
-        print('Copying installer to ' + destination)
-        shutil.copy(source, destination)
-
-        # only remove failure signal once process is successful
-        os.remove(failFile)
-        os.remove(source)
-    else:
+    if not path.exists(source):
         print('FAILURE: Built installer missing: ' + source)
 
+    # release candidates copied to their own location
+    if IS_RELEASE:
+        copyDestination = os.path.join(copyDestination, 'Release')
+    else:
+        copyDestination = os.path.join(copyDestination, 'Beta')
+    os.makedirs(copyDestination)
+
+    destination = os.path.join(copyDestination, source)
+    print('Copying installer to ' + destination)
+    shutil.copy(source, destination)
+
+    # only remove failure signal once process is successful
+    os.remove(failFile)
+    os.remove(source)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/build_image.py
+++ b/build_image.py
@@ -516,14 +516,16 @@ def copyInstaller(copyDestination : str, source : str, IS_RELEASE : bool):
     if not path.exists(source):
         print('FAILURE: Built installer missing: ' + source)
 
-    # release candidates copied to their own location
     if IS_RELEASE:
         copyDestination = os.path.join(copyDestination, 'Release')
+        destination = os.path.join(copyDestination, source)
     else:
         copyDestination = os.path.join(copyDestination, 'Beta')
-    os.makedirs(copyDestination)
+        destination = os.path.join(copyDestination, '_BETA_' + source)
 
-    destination = os.path.join(copyDestination, source)
+    if not path.exists(copyDestination):
+        os.makedirs(copyDestination)
+
     print('Copying installer to ' + destination)
     shutil.copy(source, destination)
 

--- a/build_image.py
+++ b/build_image.py
@@ -536,12 +536,12 @@ def copyInstaller(copyDestination : str, source : str, IS_RELEASE : bool):
         destination = os.path.join(copyDestination, source)
     else:
         copyDestination = os.path.join(copyDestination, 'Beta')
-        destination = os.path.join(copyDestination, '_BETA_' + source)
+        destination = os.path.join(copyDestination,
+            f'_BETA_{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M')}_{source}')
 
     if not path.exists(copyDestination):
         os.makedirs(copyDestination)
 
-    destination = os.path.join(copyDestination, source)
     print('Copying installer to ' + destination)
     shutil.copy(source, destination)
 

--- a/docs/readme_developers.md
+++ b/docs/readme_developers.md
@@ -47,7 +47,7 @@ Windows Setup
 >     - the WiX install should work correctly now
 
 MacOS Setup
->- MacOS comes default with python 2.7 
+>- install python (e.g. with homebrew)
 >- install dmgbuild (at terminal: `pip install dmgbuild`)
 >   - if pip isn't installed:
 >     - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py


### PR DESCRIPTION
## Changes
- Updated year in `LICENSE.txt`  to 2024
- Changed the installer rename process
   - no longer renames to a hard-coded constant
   - for a release package, uses the package as generated by `jpackage`
   - for a beta package, prepends `_BETA_%Y-%m-%d-%H-%M` (datetime strftime format) to the file generated by `jpackage`
- Added a command line flag, `--type_o`, that is forwarded to the call to `jpackage --type` if it's provided
   - in the case of linux, it internally tries to figure out what the underlying system type is based on the contents of `/etc/os-release` if this flag is not set. I have a machine with both `dpkg` and `rpm` installed, which is why

## Notes
- this allows for release of rpm builds, as the hard-coded path for linux was deb
   - the inclusion of the architecture in the file paths is also useful
- also keeps the version number in the package, which I like
- this is basically a preview of what I'm imagining are going to be the assets in the next release

Example release files
| OS environment | Release file name(s) |
| --- | --- |
| Linux x86 | polyglot-linear-a_3.6-1_amd64.deb<br>polyglot-linear-a-3.6-1.x86_64.rpm |
| Linux ARM | polyglot-linear-a-3.6-1.aarch64.rpm |
| OSX ARM | PolyGlot-3.6.dmg |
| Windows x86| PolyGlot-3.6.exe |

Example beta file name
| OS environment | Beta file name(s) |
| --- | --- |
| Linux x86 | _BETA_2024-11-08-15-12_polyglot-linear-a_3.6-1_amd64.deb<br>_BETA_2024-11-08-15-13_polyglot-linear-a-3.6-1.x86_64.rpm |
| OSX ARM | _BETA_2024-11-08-17-48_PolyGlot-3.6.dmg |
| Windows x86 | _BETA_2024-11-08-14-32_PolyGlot-3.6.9703.exe |

## How to generate packages (examples)
Release: `python3 build_image.py --release --copyDestination .`  
Beta: `python3 build_image.py --copyDestination .`

Draft:
- [x] testing on osx
- [x] testing on windows