### PR TITLE
Fix window un-maximizing when changing scenes. Partially addresses #1385

### DIFF
--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/CustomControls/PFrame.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/CustomControls/PFrame.java
@@ -120,6 +120,7 @@ public abstract class PFrame extends JFrame implements FocusListener {
         } else {
             frameState = -1;
         }
+        PolyGlot.getPolyGlot().getOptionsManager().setMaximized(frameState == Frame.MAXIMIZED_BOTH);
     }
 
     /**

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLexicon.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLexicon.java
@@ -42,7 +42,6 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLexicon.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLexicon.java
@@ -515,17 +515,6 @@ public final class ScrLexicon extends PFrame {
                 pnlClasses.add(classBox, gbc);
                 classPropMap.put(curProp.getId(), classBox); // combobox mapped to related class ID.
             }
-
-            if (menuParent != null) {
-                // messy, but gets a full rebuild of screen since this is happening post-initial visibility-pop
-                Dimension dim = menuParent.getSize();
-                menuParent.setSize(dim.width, dim.height + 1);
-                menuParent.setSize(dim.width, dim.height);
-
-                // Restore maximization if needed, since the above mess broke it
-                if(PolyGlot.getPolyGlot().getOptionsManager().isMaximized())
-                    menuParent.setExtendedState(getExtendedState() | Frame.MAXIMIZED_BOTH);
-            }
         }
 
         if (propList.length == 0) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLexicon.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLexicon.java
@@ -42,6 +42,7 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
@@ -520,6 +521,10 @@ public final class ScrLexicon extends PFrame {
                 Dimension dim = menuParent.getSize();
                 menuParent.setSize(dim.width, dim.height + 1);
                 menuParent.setSize(dim.width, dim.height);
+
+                // Restore maximization if needed, since the above mess broke it
+                if(PolyGlot.getPolyGlot().getOptionsManager().isMaximized())
+                    menuParent.setExtendedState(getExtendedState() | Frame.MAXIMIZED_BOTH);
             }
         }
 


### PR DESCRIPTION
This addresses the un-maximizing issue mentioned in #1385, and makes the maximized option keep track of changes as they happen.

Before merging this PR, check why the revalidation in `ScrLexicon` was needed in the first place; this may be causing a regression I've missed.