### PR TITLE
Address overzealous file save dialog which is preventing users from saving

### DIFF
--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopIOHandler.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopIOHandler.java
@@ -405,9 +405,10 @@ public final class DesktopIOHandler implements IOHandler {
                 PolyGlot.getTestShell(test);
                 test.readFile(tmpSaveFinalLocation.getAbsolutePath());
 
-                if (!core.equals(test)) {
-                    throw new Exception("Written file does not match file in memory.");
-                }
+                // TODO: Once #1393 is complete, uncomment this - until then it does more damage than good.
+//                if (!core.equals(test)) {
+//                    throw new Exception("Written file does not match file in memory.");
+//                }
             } catch (Exception ex) {
                 throw new IOException(ex);
             }


### PR DESCRIPTION
This comments out the code which checks the final file integrity after saving. It is doing far more damage than good right now, and until the XML file structure is replaced with JSON, there won't be any reliable way to have this safety feature enabled.