### PR TITLE
Remove Java 8 Pt 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>5.4.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.4.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.9.0</version>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -13,6 +13,8 @@ module org.darisadesigns.polyglotlina.polyglot {
     requires jdk.httpserver;
     requires org.apache.commons.lang3;
     requires org.apache.commons.csv; //AUT - fixed with module injector
+    requires org.apache.poi.poi;
+    requires org.apache.poi.ooxml;
     requires org.jsoup;
     
     exports org.darisadesigns.polyglotlina;

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopPropertiesManager.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopPropertiesManager.java
@@ -222,6 +222,7 @@ public class DesktopPropertiesManager extends PropertiesManager {
      *
      * @return the fontCon
      */
+    @Override
     public Font getFontCon() {
         // create copy so that initial font properties (such as kerning) is never lost
         Font retFont = conFont == null ? null : conFont.deriveFont((float)0.0);

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/ExportFileHelper.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/ExportFileHelper.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright (c) 2014-2025, Draque Thompson, draquemail@gmail.com
+ * All rights reserved.
+ *
+ * Licensed under: MIT Licence
+ * See LICENSE.TXT included with this code to read the full license agreement.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.darisadesigns.polyglotlina.Desktop;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.darisadesigns.polyglotlina.WebInterface;
+import org.darisadesigns.polyglotlina.ManagersCollections.ConjugationManager;
+import org.darisadesigns.polyglotlina.DictCore;
+import org.darisadesigns.polyglotlina.Nodes.ConWord;
+import org.darisadesigns.polyglotlina.Nodes.ConjugationNode;
+import org.darisadesigns.polyglotlina.Nodes.ConjugationPair;
+import org.darisadesigns.polyglotlina.Nodes.PronunciationNode;
+import org.darisadesigns.polyglotlina.Nodes.TypeNode;
+import org.darisadesigns.polyglotlina.Nodes.WordClass;
+import org.darisadesigns.polyglotlina.Nodes.WordClassValue;
+
+public class ExportFileHelper {
+    public ExportFileHelper() {
+        //
+    }
+
+    /**
+     * Exports a dictionary to an excel file
+     * 
+     * @param filename File to export to
+     * @param core dictionary core
+     * @param separateDeclensions whether to separate parts of speech into
+     * separate pages for declension values
+     * @throws java.io.Exception
+     */
+    public static void exportExcelToDict(String filename, DictCore core,
+        boolean separateDeclensions) throws Exception {
+
+        Workbook workbook = null;
+        Sheet sheet = null;
+        if (filename.endsWith(".xlsx")) {
+            workbook = new XSSFWorkbook();
+        } else if (filename.endsWith(".xls")) {
+            workbook = new HSSFWorkbook();
+        } else {
+            throw new Exception("Unsupported file format: " + filename);
+        }
+
+        CellStyle localStyle = workbook.createCellStyle();
+        localStyle.setWrapText(true);
+        Font boldFont = workbook.createFont();
+        boldFont.setBold(true);
+        CellStyle boldHeader = workbook.createCellStyle();
+        boldHeader.setWrapText(true);
+        boldHeader.setFont(boldFont);
+        Font conFont = workbook.createFont();
+        conFont.setFontName(core.getPropertiesManager().getFontCon().getFontName());
+        CellStyle conStyle = workbook.createCellStyle();
+        conStyle.setWrapText(true);
+        conStyle.setFont(conFont);
+
+        // record words
+        // separate words by part of spech if requested so that each POS can have distinct declension
+        // columns
+        if (separateDeclensions) {
+            // create separate page for each part of speech
+            for (TypeNode type : core.getTypes().getNodes()) {
+                ConWord filter = new ConWord();
+                filter.setWordTypeId(type.getId());
+
+                try {
+                    ConWord[] list = core.getWordCollection().filteredList(filter);
+                    if (list.length == 0) {
+                        continue; // no words, no sheet
+                    }
+
+                    sheet = workbook.createSheet(legalWorksheetName("Lex-" + type.getValue()));
+
+                    Row row = sheet.createRow(0);
+                    row.createCell(0).setCellValue(core.conLabel().toUpperCase() + " WORD");
+                    row.createCell(1).setCellValue(core.localLabel().toUpperCase() + " WORD");
+                    row.createCell(2).setCellValue("PoS");
+                    row.createCell(3).setCellValue("PRONUNCIATION");
+                    row.createCell(4).setCellValue("ROMANIZATION");
+                    row.createCell(5).setCellValue("CLASS(ES)");
+
+                    // create column for each declension
+                    ConjugationPair[] conjList = core.getConjugationManager().getAllCombinedIds(type.getId());
+                    int colNum = 5;
+                    for (ConjugationPair curDec : conjList) {
+                        colNum++;
+                        row.createCell(colNum).setCellValue(curDec.label.toUpperCase());;
+                    }
+
+                    row.createCell(colNum + 1).setCellValue("DEFINITION");
+
+                    int rowCount  =1;
+                    for (ConWord word : list) {
+                        row = sheet.createRow(rowCount);
+
+                        Object[] wordArray = getWordForm(core, word, conjList).toArray();
+                        for (int colCount = 0; colCount < wordArray.length; colCount++) {
+                            Cell cell = row.createCell(colCount);
+                            cell.setCellValue((String)wordArray[colCount]);
+
+                            if (colCount == 0 || (colCount > 4 && colCount < wordArray.length - 1)) {
+                                cell.setCellStyle(conStyle);
+                            } else {
+                                cell.setCellStyle(localStyle);
+                            }
+                        }
+                        rowCount++;
+                    }
+                } catch (Exception e) {
+                    System.out.println("Unable to export " + type.getValue() + " lexical values");
+                }
+            }
+        } else {
+            // old style of printing words
+            sheet = workbook.createSheet("Lexicon");
+            Map<Integer, ConjugationPair[]> typeDecMap = new HashMap<>();
+            
+            Row row = sheet.createRow(0);
+            row.createCell(0).setCellValue(core.conLabel().toUpperCase() + " WORD");
+            row.createCell(1).setCellValue(core.localLabel().toUpperCase() + " WORD");
+            row.createCell(2).setCellValue("PoS");
+            row.createCell(3).setCellValue("PRONUNCIATION");
+            row.createCell(4).setCellValue("CLASS(ES)");
+            row.createCell(5).setCellValue("DECLENSIONS");
+            row.createCell(6).setCellValue("DEFINITIONS");
+
+            int i = 0;
+            for (ConWord word : core.getWordCollection().getWordNodes()) {
+                i++;
+                ConjugationPair[] decList;
+
+                if (typeDecMap.containsKey(word.getWordTypeId())) {
+                    decList = typeDecMap.get(word.getWordTypeId());
+                } else {
+                    decList = core.getConjugationManager().getAllCombinedIds(word.getWordTypeId());
+                    typeDecMap.put(word.getWordTypeId(), decList);
+                }
+
+                Object[] wordArray = getWordFormOld(core, word, decList);
+                row = sheet.createRow(i);
+                for (Integer j = 0; j < wordArray.length; j++) {
+                    Cell cell = row.createCell(j);
+                    cell.setCellValue((String) wordArray[j]);
+
+                    if (j == 0) {
+                        cell.setCellStyle(conStyle);
+                    } else {
+                        cell.setCellStyle(localStyle);
+                    }
+                }
+            }
+        }
+        
+        // record types on sheet
+        sheet = workbook.createSheet("Parts of Speech");
+        Row row = sheet.createRow(0);
+        row.createCell(0).setCellValue("PoS");
+        row.createCell(1).setCellValue("NOTES");
+
+        int i = 0;
+        for (TypeNode curNode : core.getTypes().getNodes()) {
+            i++;
+
+            row = sheet.createRow(i);
+            Cell cell = row.createCell(0);
+            cell.setCellValue(curNode.getValue());
+            cell = row.createCell(1);
+            cell.setCellValue(WebInterface.getTextFromHtml(curNode.getNotes()));
+            cell.setCellStyle(localStyle);
+        }
+
+        // record word classes on sheet
+        WordClass[] classes = core.getWordClassCollection().getAllWordClasses();
+
+        if (classes.length != 0) {
+            sheet = workbook.createSheet("Lexical Classes");
+            int propertyColumn = 0;
+            for (WordClass curProp : classes) {
+                // get row, if not exist, create
+                row = sheet.getRow(0);
+                if (row == null) {
+                    row = sheet.createRow(0);
+                }
+
+                Cell cell = row.createCell(propertyColumn);
+                cell.setCellValue(curProp.getValue());
+                cell.setCellStyle(boldHeader);
+
+                int rowIndex = 1;
+                for (WordClassValue curVal : curProp.getValues()) {
+                    row = sheet.getRow(rowIndex);
+                    if (row == null) {
+                        row = sheet.createRow(rowIndex);
+                    }
+
+                    cell = row.createCell(propertyColumn);
+                    cell.setCellStyle(localStyle);
+                    cell.setCellValue(curVal.getValue());
+
+                    rowIndex++;
+                }
+
+                propertyColumn++;
+            }
+        }
+
+        // record pronunciation on sheet
+        sheet = workbook.createSheet("Pronunciations");
+
+        row = sheet.createRow(0);
+        row.createCell(0).setCellValue("CHARACTER(S)");
+        row.createCell(1).setCellValue("PRONUNCIATION");
+
+        i = 0;
+
+        for (PronunciationNode curNode : core.getPronunciationMgr().getPronunciations()) {
+            i++;
+            row = sheet.createRow(i);
+
+            Cell cell = row.createCell(0);
+            cell.setCellStyle(conStyle);
+            cell.setCellValue(curNode.getValue());
+
+            cell = row.createCell(1);
+            cell.setCellStyle(localStyle);
+            cell.setCellValue(curNode.getPronunciation());
+        }
+
+        try (FileOutputStream out = new FileOutputStream(new File(filename))) {
+            workbook.write(out);
+        } catch (Exception e) {
+            workbook.close();
+            throw new Exception("Unable to write to file: " + filename);
+        }
+
+        workbook.close();
+    }
+
+    /**
+     * Returns a legal worksheet name from the string handed in
+     * Illegal characters removed, forced size of 31 characters.
+     * @param startName name requested
+     * @return filtered name
+     */
+    private static String legalWorksheetName(String startName) {
+        // illegal characters: \ / * [ ] : ?
+        String ret = startName.replace("/|\\*|\\[|\\]|:|\\?", "");
+        if (ret.length() > 31) {
+            // max worksheet name length = 31 chars (why so short?!)
+            ret = ret.substring(0, 30);
+        }
+        return ret;
+    }
+    
+    /**
+     * Returns list of all legal wordforms this word can take.
+     * Accounts for overridden forms and properly filters forms marked as disabled
+     * @param core language
+     * @param conWord
+     * @param conjList
+     * @return 
+     */
+    private static List<String> getWordForm(DictCore core, ConWord conWord, ConjugationPair[] conjList) {
+        List<String> ret = new ArrayList<>();
+
+        ret.add(conWord.getValue());
+        ret.add(conWord.getLocalWord());
+        ret.add(conWord.getWordTypeDisplay());
+        try {
+            ret.add(conWord.getPronunciation());
+        } catch (Exception e) {
+            ret.add("<ERROR>");
+        }
+        
+        try {
+            ret.add(core.getRomManager().getPronunciation(conWord.getValue()));
+        } catch (Exception e) {
+            ret.add("<ERROR>");
+        }
+
+        String classes = "";
+        for (Entry<Integer, Integer> curEntry : conWord.getClassValues()) {
+            if (classes.length() != 0) {
+                classes += ", ";
+            }
+            try {
+                WordClass prop = (WordClass) core.getWordClassCollection().getNodeById(curEntry.getKey());
+                WordClassValue value = prop.getValueById(curEntry.getValue());
+                classes += value.getValue();
+            } catch (Exception e) {
+                classes = "ERROR: UNABLE TO PULL CLASS";
+            }
+        }
+        
+        for (Entry<Integer, String> curEntry : conWord.getClassTextValues()) {
+            if (classes.length() != 0) {
+                classes += ", ";
+            }
+            
+            try {
+                WordClass prop = (WordClass) core.getWordClassCollection().getNodeById(curEntry.getKey());
+                classes += prop.getValue() + ":" + curEntry.getValue();
+            } catch (Exception e) {
+                classes = "ERROR: UNABLE TO PULL CLASS";
+            }
+        }
+        
+        ret.add(classes);
+
+        for (ConjugationPair conjugation : conjList) {
+            try {
+                ConjugationManager conMan= core.getConjugationManager();
+                ConjugationNode existingValue = conMan.getConjugationByCombinedId(conWord.getId(), conjugation.combinedId);
+                
+                if (existingValue != null && conWord.isOverrideAutoConjugate()) {
+                    ret.add(existingValue.getValue());
+                }
+                else {
+                    ret.add(conMan.declineWord(conWord, conjugation.combinedId));
+                }
+            } catch (Exception e) {
+                ret.add("DECLENSION ERROR");
+            }
+        }
+        
+        ret.add(WebInterface.getTextFromHtml(conWord.getDefinition()));
+
+        return ret;
+    }
+
+    private static Object[] getWordFormOld(DictCore core, ConWord conWord, ConjugationPair[] conjList) {
+        List<String> ret = new ArrayList<>();
+        String declensionCell = "";
+
+        ret.add(conWord.getValue());
+        ret.add(conWord.getLocalWord());
+        ret.add(conWord.getWordTypeDisplay());
+        try {
+            ret.add(conWord.getPronunciation());
+        } catch (Exception e) {
+            ret.add("<ERROR>");
+        }
+
+        String classes = "";
+        for (Entry<Integer, Integer> curEntry : conWord.getClassValues()) {
+            if (classes.length() != 0) {
+                classes += ", ";
+            }
+            try {
+                ConjugationManager conMan= core.getConjugationManager();
+                WordClass prop = (WordClass) core.getWordClassCollection().getNodeById(curEntry.getKey());
+                WordClassValue value = prop.getValueById(curEntry.getValue());
+                classes += value.getValue();
+            } catch (Exception e) {
+                classes = "ERROR: UNABLE TO PULL CLASS";
+            }
+        }
+        ret.add(classes);
+        
+        for (ConjugationPair conjugation : conjList) {
+            try {
+                ConjugationManager conMan= core.getConjugationManager();
+                ConjugationNode existingValue = conMan.getConjugationByCombinedId(conWord.getId(), conjugation.combinedId);
+                
+                if (existingValue != null && conWord.isOverrideAutoConjugate()) {
+                    declensionCell += existingValue.getValue() + ":";
+                }
+                else {
+                    declensionCell += conMan.declineWord(conWord, conjugation.combinedId) + ":";
+                }
+            } catch (Exception e) {
+                declensionCell += "DECLENSION ERROR";
+            }
+        }
+
+        ret.add(declensionCell);
+        ret.add(WebInterface.getTextFromHtml(conWord.getDefinition()));
+
+        return ret.toArray();
+    }
+}

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/ImportFileHelper.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/ImportFileHelper.java
@@ -20,11 +20,14 @@
 package org.darisadesigns.polyglotlina.Desktop;
 
 import java.io.File;
+import java.io.FileInputStream;
+
 import org.darisadesigns.polyglotlina.Nodes.ConWord;
 import org.darisadesigns.polyglotlina.Nodes.TypeNode;
 import org.darisadesigns.polyglotlina.Nodes.WordClassValue;
 import org.darisadesigns.polyglotlina.Nodes.WordClass;
 import java.io.FileNotFoundException;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.Charset;
@@ -33,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.csv.CSVFormat;
@@ -40,6 +44,9 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.darisadesigns.polyglotlina.DictCore;
 import org.darisadesigns.polyglotlina.ManagersCollections.ConWordCollection;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.*;
 
 public class ImportFileHelper {
 
@@ -106,9 +113,90 @@ public class ImportFileHelper {
         }
     }
 
+    /**
+     * Converts an excel spreadsheet to a temporary CSV file
+     * @param inputFile Excel to convert
+     * @param sheetNum Sheet to convert
+     * @return File reference to temp file containing CSV data
+     * @throws Exception
+     */
+    public static File convertExcelToCSV(String inputFile, int sheetNum) throws Exception {
+        File csvFile = File.createTempFile("PolyGlotTmp", ".csv",
+            PGTUtil.getTempDirectory().toFile());
+        csvFile.deleteOnExit();
+
+        try {
+            FileInputStream fis = new FileInputStream(inputFile);
+            Workbook workbook = null;
+            StringBuffer data = new StringBuffer();
+            
+            if (inputFile.endsWith(".xlsx")) {
+                workbook = new XSSFWorkbook(fis);
+            } else if (inputFile.endsWith(".xls")) {
+                workbook = new HSSFWorkbook(fis);
+            } else {
+                fis.close();
+                throw new Exception("File not supported: " + inputFile);
+            }
+            Sheet sheet = workbook.getSheetAt(sheetNum);
+
+            // iterate over rows
+            Iterator<Row> rowIt = sheet.iterator();
+            while (rowIt.hasNext()) {
+                Row row = rowIt.next();
+                // iterate over columns
+                // don't use Iterator<Cell> as `.next()` skips over blank cells
+                int totalCells = row.getLastCellNum();
+                for (int i = 0; i < totalCells; i++) {
+                    Cell cell = row.getCell(i);
+
+                    if (cell != null) {
+                        switch (cell.getCellType()) {
+                        case BOOLEAN:
+                            data.append(cell.getBooleanCellValue());
+                            break;
+                        case NUMERIC:
+                            data.append(cell.getNumericCellValue());
+                            break;
+                        case STRING:
+                            data.append('"' + cell.getStringCellValue() + "\"");
+                            break;
+                        case BLANK:
+                            data.append("");
+                            break;
+                        case FORMULA:
+                            throw new Exception("Cannot import formulas");
+                        default:
+                            data.append(cell);
+                        }
+                    } else {
+                        data.append("");
+                    }
+                    if (i != totalCells - 1) {
+                        data.append(",");
+                    }
+                }
+                data.append('\n');
+            }
+
+            FileWriter writer = new FileWriter(csvFile.getAbsolutePath());
+            writer.write(data.toString());
+            writer.close();
+            workbook.close();
+        } catch (Exception e) {
+            throw(e);
+        }
+        return csvFile;
+    }
+
+    /**
+     * Imports lexicon from excel
+     * @param inputFile file to import
+     * @param sheetNum sheet number
+     * @throws Exception
+     */
     private void importExcel(String inputFile, int sheetNum) throws Exception {
-        File csvFile = NonModularBridge.excelToCvs(inputFile, sheetNum);
-        quoteChar = "\"";
+        File csvFile = convertExcelToCSV(inputFile, sheetNum);
         importCSV(csvFile.getAbsolutePath(), CSVFormat.EXCEL);
     }
 

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/ImportFileHelper.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/ImportFileHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020, Draque Thompson, draquemail@gmail.com
+ * Copyright (c) 2014-2025, Draque Thompson, draquemail@gmail.com
  * All rights reserved.
  *
  * Licensed under: MIT Licence

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/NonModularBridge.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/NonModularBridge.java
@@ -171,42 +171,6 @@ public final class NonModularBridge {
     }
 
     /**
-     * Creates temporary csv file from excel sheet
-     * @param excelFile path of excel file to convert to csv
-     * @param sheetNumber sheet number to convert
-     * @return csv file temp path to created csv file
-     * @throws IOException
-     */
-    public static File excelToCvs(String excelFile, int sheetNumber)
-            throws IOException {
-        
-        File bridge = NonModularBridge.getNonModularBridgeLocation();
-        File tmpTarget = File.createTempFile("PolyGlotTmp", ".csv",
-            PGTUtil.getTempDirectory().toFile());
-        tmpTarget.deleteOnExit();
-        
-        String[] command = {
-            getJavaExecutablePath(),
-            PGTUtil.JAVA_JAR_ARG,
-            bridge.getAbsolutePath(),
-            PGTUtil.JAVA_EXCELTOCVSCOMMAND,
-            excelFile,
-            tmpTarget.getAbsolutePath(),
-            Integer.toString(sheetNumber),
-        };
-        
-        String[] result = DesktopIOHandler.getInstance().runAtConsole(command, false);
-        
-        if (!result[1].isEmpty() || !tmpTarget.exists()) {
-            throw new IOException(result[1]);
-        } else if (result[0].toLowerCase().contains("error") || result[0].toLowerCase().contains("exception")) {
-            throw new IOException("Unable to import excel: " + result[0]);
-        }
-        
-        return tmpTarget;
-    }
-
-    /**
      * Exports a dictionary to an excel file (externally facing)
      *
      * @param fileName Filename to export to

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/NonModularBridge.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/NonModularBridge.java
@@ -170,42 +170,6 @@ public final class NonModularBridge {
         }
     }
 
-    /**
-     * Exports a dictionary to an excel file (externally facing)
-     *
-     * @param fileName Filename to export to
-     * @param core dictionary core
-     * @param separateDeclensions whether to separate parts of speech into
-     * separate pages for declension values
-     * @throws java.io.IOException
-     */
-    public static void exportExcelDict(String fileName, DictCore core,
-            boolean separateDeclensions) throws IOException {
-        
-        File bridge = NonModularBridge.getNonModularBridgeLocation();
-        File tmpLangFile = createTmpLangFile(core);
-        
-        String[] command = {
-            getJavaExecutablePath(),
-            PGTUtil.JAVA_JAR_ARG, // -jar
-            bridge.getAbsolutePath(), // path to bridge
-            PGTUtil.JAVA_EXPORTTOEXCELCOMMAND, // export command 
-            tmpLangFile.getAbsolutePath(), // language file
-            fileName, // target file
-            (separateDeclensions ? PGTUtil.TRUE : PGTUtil.FALSE) // separate declensions
-        };
-        
-        String[] result = DesktopIOHandler.getInstance().runAtConsole(command, false);
-        
-        if (!result[1].isEmpty()) {
-            throw new IOException("Unable to export to excel: " + result[1]);
-        } else if (result[0].toLowerCase().contains("error") || result[0].toLowerCase().contains("exception")) {
-            throw new IOException("Unable to export to excel: " + result[0]);
-        } else if (!new File(fileName).exists()) {
-            throw new IOException("Unable to export to excel: File not found post export.");
-        }
-    }
-
     public static class OutputInterceptor extends PrintStream {
         //private String intercepted = "";
 

--- a/src/main/java/org/darisadesigns/polyglotlina/ManagersCollections/PropertiesManager.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/ManagersCollections/PropertiesManager.java
@@ -19,6 +19,7 @@
  */
 package org.darisadesigns.polyglotlina.ManagersCollections;
 
+import java.awt.Font;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -232,6 +233,12 @@ public abstract class PropertiesManager {
      * @param _fontSize the fontSize to set
      */
     public abstract void setFontSize(double _fontSize);
+
+    /**
+     * Get the language's font
+     * @return the fontCon
+     */
+    public abstract Font getFontCon();
     
     /**
      * 

--- a/src/main/java/org/darisadesigns/polyglotlina/ManagersCollections/PropertiesManager.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/ManagersCollections/PropertiesManager.java
@@ -575,7 +575,7 @@ public abstract class PropertiesManager {
      * @return the localLangName
      */
     public String getLocalLangName() {
-        return localLangName.trim().isEmpty() ? "Local" : localLangName;
+        return localLangName;
     }
 
     /**

--- a/src/main/java/org/darisadesigns/polyglotlina/PGTUtil.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/PGTUtil.java
@@ -321,8 +321,6 @@ public class PGTUtil {
     public static final String JAVA_JAR = "PolyGlot_J8_Bridge.jar";
     public static final String JAVA_JAR_FOLDER = "dist";
     public static final String JAVA_PDFCOMMAND = "pdf-export";
-    public static final String JAVA_EXCELTOCVSCOMMAND = "excel-to-cvs";
-    public static final String JAVA_EXPORTTOEXCELCOMMAND = "export-to-excel";
     public static final int CHAP_ORTHOGRAPHY = 0;
     public static final int CHAP_GLOSSKEY = 1;
     public static final int CHAP_CONTOLOCAL = 2;

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrEvolveLang.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrEvolveLang.java
@@ -115,7 +115,7 @@ public final class ScrEvolveLang extends PDialog {
         jPanel1 = new javax.swing.JPanel();
         jLabel1 = new PLabel("");
         txtConWordFilter = new PTextField(core, false, "ConWord Filter");
-        txtLocalWordFilter = new PTextField(core, true, core.getPropertiesManager().getLocalLangName() + " Filter");
+        txtLocalWordFilter = new PTextField(core, true, core.localLabel() + " Filter");
         cmbPoS = new PComboBox<TypeNode>( ((DesktopPropertiesManager)core.getPropertiesManager()).getFontLocal(), "Part of Speech", core);
         jPanel2 = new javax.swing.JPanel();
         jLabel2 = new PLabel("");

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrMainMenu.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrMainMenu.java
@@ -84,9 +84,9 @@ import org.darisadesigns.polyglotlina.Desktop.DesktopHelpHandler;
 import org.darisadesigns.polyglotlina.Desktop.DesktopIOHandler;
 import org.darisadesigns.polyglotlina.Desktop.DesktopOSHandler;
 import org.darisadesigns.polyglotlina.Desktop.DesktopPropertiesManager;
+import org.darisadesigns.polyglotlina.Desktop.ExportFileHelper;
 import org.darisadesigns.polyglotlina.Desktop.ManagersCollections.DesktopGrammarManager;
 import org.darisadesigns.polyglotlina.Desktop.ManagersCollections.DesktopOptionsManager;
-import org.darisadesigns.polyglotlina.Desktop.NonModularBridge;
 import org.darisadesigns.polyglotlina.Desktop.PGTUtil;
 import org.darisadesigns.polyglotlina.Desktop.PolyGlot;
 import org.darisadesigns.polyglotlina.DictCore;
@@ -776,9 +776,9 @@ public final class ScrMainMenu extends PFrame {
                 || new DesktopInfoBox(this).actionConfirmation("Overwrite File?",
                         "File with this name and location already exists. Continue/Overwrite?")) {
             try {
-                NonModularBridge.exportExcelDict(fileName, core,
-                        new DesktopInfoBox(this).actionConfirmation("Excel Export",
-                                "Export all declensions? (Separates parts of speech into individual tabs)"));
+                ExportFileHelper.exportExcelToDict(fileName, core,
+                    new DesktopInfoBox(this).actionConfirmation("Excel Export",
+                        "Export all declensions? (Separates parts of speech into individual tabs)"));
 
                 // only prompt user to open if Desktop supported
                 if (Desktop.isDesktopSupported()) {
@@ -789,7 +789,7 @@ public final class ScrMainMenu extends PFrame {
                     new DesktopInfoBox(this).info("Export Status", "Language exported to " + fileName + ".");
                 }
             }
-            catch (IOException e) {
+            catch (Exception e) {
                 DesktopIOHandler.getInstance().writeErrorLog(e);
                 new DesktopInfoBox(this).info("Export Problem", e.getLocalizedMessage());
             }

--- a/src/main/java/org/darisadesigns/polyglotlina/WebInterface.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/WebInterface.java
@@ -95,7 +95,7 @@ public class WebInterface {
                 = new org.jsoup.nodes.Document.OutputSettings();
         outputSettings.prettyPrint(false);
         
-        // jsoup is not great with preservartion of linebraks...
+        // jsoup is not great with preservartion of linebreaks...
         if (text.contains("<body>")) {
             text = text.substring(text.indexOf("<body>"), text.indexOf("</body>") + 7);
         }

--- a/src/test/java/org/darisadesigns/polyglotlina/CheckLanguageErrorsTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/CheckLanguageErrorsTest.java
@@ -78,7 +78,7 @@ public class CheckLanguageErrorsTest {
         
         curWord = problems[3];
         assertEquals("missing-local-noun", curWord.problemWord.getValue());
-        assertEquals("Local word set to mandatory.", curWord.description);
+        assertEquals("Local Lang word set to mandatory.", curWord.description);
     }
     
     @Test

--- a/src/test/java/org/darisadesigns/polyglotlina/ExportFileHelperTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/ExportFileHelperTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2019-2025, Draque Thompson, draquemail@gmail.com
+ * All rights reserved.
+ *
+ * Licensed under: MIT Licence
+ * See LICENSE.TXT included with this code to read the full license agreement.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.darisadesigns.polyglotlina;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.darisadesigns.polyglotlina.Desktop.DesktopIOHandler;
+import org.darisadesigns.polyglotlina.Desktop.ExportFileHelper;
+import org.darisadesigns.polyglotlina.Desktop.ImportFileHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import TestResources.DummyCore;
+
+public class ExportFileHelperTest {
+    private DictCore core;
+    private static final String OUTPUT = "testFile.xls";
+    public ExportFileHelperTest() {
+        core = DummyCore.newCore();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        new File(OUTPUT).delete();
+        core = DummyCore.newCore();
+    }
+ 
+    @Test
+    public void testExportExcelDict() {
+        System.out.println("ExportFileHelperTest.testExportExcelDict");
+        String os = System.getProperty("os.name").toLowerCase();
+        
+        try {
+            core.readFile(PGTUtil.TESTRESOURCES + "excel_exp_test.pgd");
+            boolean separateDeclensions = true;
+            ExportFileHelper.exportExcelToDict(OUTPUT, core, separateDeclensions);
+            File tmpExcel = new File(OUTPUT);
+
+            for (int i = 0 ; i < 6; i++) {
+                File expectedFile = new File(PGTUtil.TESTRESOURCES + "excel_export_check_" + i + ".csv");
+                File result = ImportFileHelper.convertExcelToCSV(tmpExcel.getAbsolutePath(), i);
+                
+                // On modification of functionality, check output, then uncomment below to update test files if good
+//                expectedFile.delete();
+//                Files.copy(result.toPath(), expectedFile.toPath());
+
+                byte[] expBytes = Files.readAllBytes(expectedFile.toPath());
+                byte[] resBytes = Files.readAllBytes(result.toPath());
+
+                // windows expected file will be in crlf (due to git translation of file)... gotta sanitize.
+                int carRet = 13;
+                if (os.toLowerCase().contains("win")) {
+                    int index = 0; 
+                    for (int k = 0; k < expBytes.length; k++) {
+                       if (expBytes[k] != carRet) {
+                          expBytes[index++] = expBytes[k];
+                       }
+                    }
+
+                   expBytes = Arrays.copyOf(expBytes, index); 
+                }
+
+                assertTrue(Arrays.equals(expBytes, resBytes));
+            }
+        } catch (IOException | IllegalStateException | ParserConfigurationException e) {
+            DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
+            fail(e);
+        } catch (Exception e) {
+            DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
+            fail(e);
+        }
+    }
+}

--- a/src/test/java/org/darisadesigns/polyglotlina/ImportFileHelperTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/ImportFileHelperTest.java
@@ -20,7 +20,14 @@
 package org.darisadesigns.polyglotlina;
 
 import TestResources.DummyCore;
+
+import org.darisadesigns.polyglotlina.Desktop.DesktopIOHandler;
 import org.darisadesigns.polyglotlina.Desktop.ImportFileHelper;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.csv.CSVFormat;
@@ -166,5 +173,56 @@ public class ImportFileHelperTest {
             fail(e);
         }
     }
+
+    @Test
+    public void testExcelToCsv() {
+        System.out.println("ImportFileHelperTest.testExcelToCsv");
+        String expectedContents = "\"COL 1\",\"COL 2\",\"COL 3\"\n" +
+            "\"A\",\"AA\",\"AAA\"\n" +
+            "\"B\"\n" +
+            "\"C\",\"CC\",\"CCC\",\"CCCC\"\n" +
+            "\"E\",,\"EEE\"\n" +
+            "\"F\",\"F\n" +
+            "F\",\"F\n" +
+            "F\n" +
+            "F\"\n" +
+            "\"\"G\"\",\"G'\",\",G\"";
+        String excelFile = PGTUtil.TESTRESOURCES + "excelImport.xlsx";
+        int sheetNumber = 0;
+        
+        try {
+            File result = ImportFileHelper.convertExcelToCSV(excelFile, sheetNumber);
+            String outputContents = readFile(result.getAbsolutePath());
+
+            assertTrue(result.exists());
+            assertEquals(expectedContents, outputContents);
+        } catch (Exception e) {
+            DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
+            fail(e);
+        }
+    }
     
+    private String readFile(String fileIn) {
+        String ret = "";
+        
+        try (BufferedReader reader = new BufferedReader(new FileReader(fileIn))) {
+            String line = reader.readLine();
+            
+            while (line != null) {
+                ret += line + "\n";
+                line = reader.readLine();
+            }
+            
+            if (!ret.isEmpty()) {
+                ret = ret.substring(0, ret.length() - 1);
+            }
+        } catch (FileNotFoundException e) {
+            ret = null;
+        } catch (Exception e) {
+            DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
+            fail(e);
+        }
+        
+        return ret;
+    }
 }

--- a/src/test/java/org/darisadesigns/polyglotlina/ManagersCollections/ConWordCollectionTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/ManagersCollections/ConWordCollectionTest.java
@@ -97,7 +97,7 @@ public class ConWordCollectionTest extends PTest {
     @Test
     public void testMissingLocalWordWithRequirement() {
         System.out.println("ConWordCollectionTest.testMissingLocalWordWithRequirement");
-        String expectedResult = "Local word set to mandatory.";
+        String expectedResult = "Local Lang word set to mandatory.";
         
         DictCore core = DummyCore.newCore();
         ConWord test = new ConWord();

--- a/src/test/java/org/darisadesigns/polyglotlina/NonModularBridgeTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/NonModularBridgeTest.java
@@ -20,10 +20,7 @@
 package org.darisadesigns.polyglotlina;
 
 import TestResources.DummyCore;
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -104,52 +101,6 @@ public class NonModularBridgeTest {
             );
             assertTrue(new File(OUTPUT).exists());
         } catch (IOException e) {
-            DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
-            fail(e);
-        }
-    }
- 
-    @Test
-    public void testExportExcelDict() {
-        System.out.println("NonModularBridgeTest.exportExcelDict");
-        String os = System.getProperty("os.name").toLowerCase();
-        
-        try {
-            core.readFile(PGTUtil.TESTRESOURCES + "excel_exp_test.pgd");
-            boolean separateDeclensions = true;
-            NonModularBridge.exportExcelDict(OUTPUT, core, separateDeclensions);
-            File tmpExcel = new File(OUTPUT);
-
-            for (int i = 0 ; i < 6; i++) {
-                File expectedFile = new File(PGTUtil.TESTRESOURCES + "excel_export_check_" + i + ".csv");
-                File result = ImportFileHelper.convertExcelToCSV(tmpExcel.getAbsolutePath(), i);
-                
-                // On modification of bridge functionality, check output, then uncomment below to update test files if good
-//                expectedFile.delete();
-//                Files.copy(result.toPath(), expectedFile.toPath());
-
-                byte[] expBytes = Files.readAllBytes(expectedFile.toPath());
-                byte[] resBytes = Files.readAllBytes(result.toPath());
-
-                // windows expected file will be in crlf (due to git translation of file)... gotta sanitize.
-                int carRet = 13;
-                if (os.toLowerCase().contains("win")) {
-                    int index = 0; 
-                    for (int k = 0; k < expBytes.length; k++) {
-                       if (expBytes[k] != carRet) {
-                          expBytes[index++] = expBytes[k];
-                       }
-                    }
-
-                   expBytes = Arrays.copyOf(expBytes, index); 
-                }
-
-                assertTrue(Arrays.equals(expBytes, resBytes));
-            }
-        } catch (IOException | IllegalStateException | ParserConfigurationException e) {
-            DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
-            fail(e);
-        } catch (Exception e) {
             DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
             fail(e);
         }

--- a/src/test/java/org/darisadesigns/polyglotlina/NonModularBridgeTest.java
+++ b/src/test/java/org/darisadesigns/polyglotlina/NonModularBridgeTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import javax.xml.parsers.ParserConfigurationException;
 import org.darisadesigns.polyglotlina.Desktop.DesktopIOHandler;
 import org.darisadesigns.polyglotlina.Desktop.NonModularBridge;
+import org.darisadesigns.polyglotlina.Desktop.ImportFileHelper;
 import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,7 @@ import org.junit.jupiter.api.Test;
  */
 public class NonModularBridgeTest {
     private DictCore core;
-    private static final String OUTPUT = "testFile";
+    private static final String OUTPUT = "testFile.xls";
     
     public NonModularBridgeTest() {
         core = DummyCore.newCore();
@@ -107,34 +108,6 @@ public class NonModularBridgeTest {
             fail(e);
         }
     }
-
-    @Test
-    public void testExcelToCvs() {
-        System.out.println("NonModularBridgeTest.excelToCvs");
-        String expectedContents = "\"COL 1\",\"COL 2\",\"COL 3\"\n" +
-            "\"A\",\"AA\",\"AAA\"\n" +
-            "\"B\"\n" +
-            "\"C\",\"CC\",\"CCC\",\"CCCC\"\n" +
-            "\"E\",,\"EEE\"\n" +
-            "\"F\",\"F\n" +
-            "F\",\"F\n" +
-            "F\n" +
-            "F\"\n" +
-            "\"\"\"G\"\"\",\"G'\",\",G\"";
-        String excelFile = PGTUtil.TESTRESOURCES + "excelImport.xlsx";
-        int sheetNumber = 0;
-        
-        try {
-            File result = NonModularBridge.excelToCvs(excelFile, sheetNumber);
-            String outputContents = readFile(result.getAbsolutePath());
-
-            assertTrue(result.exists());
-            assertEquals(outputContents, expectedContents);
-        } catch (IOException e) {
-            DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
-            fail(e);
-        }
-    }
  
     @Test
     public void testExportExcelDict() {
@@ -149,7 +122,7 @@ public class NonModularBridgeTest {
 
             for (int i = 0 ; i < 6; i++) {
                 File expectedFile = new File(PGTUtil.TESTRESOURCES + "excel_export_check_" + i + ".csv");
-                File result = NonModularBridge.excelToCvs(tmpExcel.getAbsolutePath(), i);
+                File result = ImportFileHelper.convertExcelToCSV(tmpExcel.getAbsolutePath(), i);
                 
                 // On modification of bridge functionality, check output, then uncomment below to update test files if good
 //                expectedFile.delete();
@@ -176,35 +149,14 @@ public class NonModularBridgeTest {
         } catch (IOException | IllegalStateException | ParserConfigurationException e) {
             DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
             fail(e);
+        } catch (Exception e) {
+            DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
+            fail(e);
         }
     }
     
     private void cleanup() {
         new File(OUTPUT).delete();
         core = DummyCore.newCore();
-    }
-    
-    private String readFile(String fileIn) {
-        String ret = "";
-        
-        try (BufferedReader reader = new BufferedReader(new FileReader(fileIn))) {
-            String line = reader.readLine();
-            
-            while (line != null) {
-                ret += line + "\n";
-                line = reader.readLine();
-            }
-            
-            if (!ret.isEmpty()) {
-                ret = ret.substring(0, ret.length() - 1);
-            }
-        } catch (FileNotFoundException e) {
-            ret = null;
-        } catch (Exception e) {
-            DesktopIOHandler.getInstance().writeErrorLog(e, e.getLocalizedMessage());
-            fail(e);
-        }
-        
-        return ret;
     }
 }


### PR DESCRIPTION
## Changes
- Add apache poi v 5.4.0
- Moved `NonModularBridge.excelToCvs` to `ImportFileHelper.convertExcelToCSV`
- Created new file `ExportFileHelper`
   - moved `NonModularBridge.exportExcelDict` to `ExportFileHelper.exportExcelToDict`
   - moved code from PolyGlotPDF to this new function
- Added abstract function `getFontCon` to `PropertiesManager.java`
   - this exists in PolyGlotPDF and is called through this abstract class
- Simplified `PropertiesManager.getLocalFontCon` to match PolyGlotPDF's implementation

## Notes
- this is bring in code/functionality that exists here: https://github.com/DraqueT/PolyGlotPDF
- this has a minor change in some calls to getting the name of the local lang. hopefully this doesn't break things
- since this is taking a while, I've decided to move the replacement of `itext` into another PR to keep things going

## Impact
- Code essentially external to the project is now moved to be in here
- Should remove class of errors related to two different implementations of DictCtore