### PR TITLE
Cleanup Warnings, Minor Code Updates

### DIFF
--- a/src/main/java/org/darisadesigns/polyglotlina/CustomControls/GrammarChapNode.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/CustomControls/GrammarChapNode.java
@@ -20,6 +20,7 @@
 package org.darisadesigns.polyglotlina.CustomControls;
 
 import java.util.Enumeration;
+import javax.swing.tree.TreeNode;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -38,7 +39,7 @@ public interface GrammarChapNode {
     public String getName();
     public void setName(String _name);
     public int getChildCount();
-    public Enumeration children(String _filter);
+    public Enumeration<? extends TreeNode> children(String _filter);
     public void writeXML(Document doc, Element rootElement);
     public GrammarSectionNode getChild(int i);
 }

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/CustomControls/PTableModel.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/CustomControls/PTableModel.java
@@ -20,23 +20,73 @@
 package org.darisadesigns.polyglotlina.Desktop.CustomControls;
 
 import org.darisadesigns.polyglotlina.Nodes.DictNode;
-import javax.swing.table.DefaultTableModel;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
 
 /**
- * Obsolete collection used because that's what underlying class API is built on...
  * @author draque.thompson
  */
-public class PTableModel extends DefaultTableModel {
-    public PTableModel(Object[] columnNames, int rowCount) {
-        super(convertToVector(columnNames), rowCount);
+public class PTableModel extends AbstractTableModel {
+    private List<DictNode[]> rows;
+    private final String columnNames[];
+
+    public PTableModel(String[] columnNames) {
+        this.columnNames = columnNames;
+        rows = new ArrayList<>();
     }
-    
+
     @Override
-    @SuppressWarnings("UseOfObsoleteCollectionType")
-    public void setValueAt(Object aValue, int row, int column) {
-        java.util.Vector rowVector = dataVector.elementAt(row);
-        DictNode node = (DictNode)rowVector.get(column);
-        node.setValue(aValue.toString());
-        fireTableCellUpdated(row, column);
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        if (columnIndex < 0 || columnIndex >= columnNames.length) {
+            return false;
+        }
+        if (rowIndex < 0 || rowIndex >= rows.size()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columnNames.length;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return columnNames[column];
+    }
+
+    @Override
+    public int getRowCount() {
+        return rows.size();
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        return rows.get(rowIndex)[columnIndex];
+    }
+
+    @Override
+    public void setValueAt(Object value, int rowIndex, int columnIndex) {
+        rows.get(rowIndex)[columnIndex] = (DictNode) value;
+        fireTableCellUpdated(rowIndex, columnIndex);
+    }
+
+    public void addRow(DictNode[] row) {
+        if (row.length != columnNames.length) {
+            throw new IllegalArgumentException("Row length must match column count");
+        }
+        rows.add(row);
+        fireTableRowsInserted(rows.size() - 1, rows.size() - 1);
+    }
+
+    public void removeRow(int rowIndex) {
+        if (rowIndex < 0 || rowIndex >= rows.size()) {
+            throw new IndexOutOfBoundsException("Row index out of range");
+        }
+        rows.remove(rowIndex);
+        fireTableRowsDeleted(rowIndex, rowIndex);
     }
 }

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopPFontHandler.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopPFontHandler.java
@@ -303,7 +303,7 @@ public class DesktopPFontHandler extends org.darisadesigns.polyglotlina.PFontHan
                 || path.toLowerCase().endsWith(".dfont")) {
             try {
                 Font f = Font.createFont(Font.TRUETYPE_FONT, fontFile);
-                Map attributes = f.getAttributes();
+                Map<TextAttribute, Object> attributes = new HashMap<>(f.getAttributes());
                 attributes.put(TextAttribute.LIGATURES, TextAttribute.LIGATURES_ON);
                 f = f.deriveFont(attributes);
 
@@ -339,7 +339,7 @@ public class DesktopPFontHandler extends org.darisadesigns.polyglotlina.PFontHan
     public static Font getFontFromFile(String filePath) throws FontFormatException, IOException {
         File fontFile = new File(filePath);
         Font ret = Font.createFont(Font.TRUETYPE_FONT, fontFile);
-        Map attributes = ret.getAttributes();
+        Map<TextAttribute, Object> attributes = new HashMap<>(ret.getAttributes());
         attributes.put(TextAttribute.LIGATURES, TextAttribute.LIGATURES_ON);
         ret = ret.deriveFont(attributes);
 

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopPFontHandler.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/DesktopPFontHandler.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
@@ -77,14 +78,13 @@ public class DesktopPFontHandler extends org.darisadesigns.polyglotlina.PFontHan
      * @return returns loaded font file on success, null otherwise
      */
     public static Font loadFontFromOSFileFolder(String fontFamily) {
-        Font ret = null;
         try {
             File fontFile = getFontFile(fontFamily);
             if (fontFile != null && fontFile.exists()) {
-                ret = Font.createFont(Font.TRUETYPE_FONT, fontFile);
-                Map attributes = ret.getAttributes();
+                Font font = Font.createFont(Font.TRUETYPE_FONT, fontFile);
+                Map<TextAttribute, Object> attributes = new HashMap<>(font.getAttributes());
                 attributes.put(TextAttribute.LIGATURES, TextAttribute.LIGATURES_ON);
-                ret = ret.deriveFont(attributes);
+                return font.deriveFont(attributes);
             }
         }
         catch (Exception e) {
@@ -92,7 +92,7 @@ public class DesktopPFontHandler extends org.darisadesigns.polyglotlina.PFontHan
             // do nothing here. Failure means returning null
         }
 
-        return ret;
+        return null;
     }
 
     /**

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/ImportFileHelper.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/ImportFileHelper.java
@@ -201,12 +201,14 @@ public class ImportFileHelper {
     }
 
     private void importCSV(String inputFile, CSVFormat _format) throws Exception {
+        CSVFormat.Builder builder = _format.builder();
         if (!quoteChar.isEmpty()) {
-            _format = _format.withQuote(quoteChar.charAt(0));
+            builder.setQuote(quoteChar.charAt(0));
         }
+        CSVFormat format = builder.build();
 
         Map<String, List<ConWord>> valueMap = core.getWordCollection().getValueMapping();
-        List<List<String>> rows = getRows(inputFile, _format);
+        List<List<String>> rows = getRows(inputFile, format);
         ConWordCollection wordCollection = core.getWordCollection();
 
         if (bFirstLineLabels) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/ManagersCollections/DesktopGrammarManager.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/ManagersCollections/DesktopGrammarManager.java
@@ -20,7 +20,7 @@
 package org.darisadesigns.polyglotlina.Desktop.ManagersCollections;
 
 import java.util.Arrays;
-import java.util.Map.Entry;
+import java.util.Map;
 import java.util.Objects;
 import org.darisadesigns.polyglotlina.Desktop.CustomControls.DesktopGrammarChapNode;
 import org.darisadesigns.polyglotlina.Desktop.CustomControls.DesktopGrammarSectionNode;
@@ -69,15 +69,11 @@ public class DesktopGrammarManager extends GrammarManager {
             ret = chapters.equals(compMan.chapters);
             
             if (ret) {
-                for (Object o : soundMap.entrySet().toArray()) {
-                    Entry<Integer, byte[]> entry = (Entry<Integer, byte[]>)o;
-
+                for (Map.Entry<Integer, byte[]> entry : soundMap.entrySet()) {
                     int id = entry.getKey();
                     byte[] soundVal = entry.getValue();
 
-                    ret = compMan.soundMap.containsKey(id);
-
-                    if (ret) {
+                    if (compMan.soundMap.containsKey(id)) {
                         ret = Arrays.equals(soundVal, compMan.soundMap.get(id));
                     } else {
                         break;

--- a/src/main/java/org/darisadesigns/polyglotlina/ManagersCollections/ConjugationManager.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/ManagersCollections/ConjugationManager.java
@@ -1054,7 +1054,7 @@ public class ConjugationManager {
      *
      * @param wordId ID of word to clear of all declensions
      */
-    private void clearAllConjugations(Integer wordId, Map list) {
+    private void clearAllConjugations(Integer wordId, Map<Integer, List<ConjugationNode>> list) {
         list.remove(wordId);
     }
 

--- a/src/main/java/org/darisadesigns/polyglotlina/Nodes/ConWord.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Nodes/ConWord.java
@@ -128,7 +128,7 @@ public class ConWord extends DictNode {
     }
 
     @Override
-    public void setParent(DictionaryCollection _parent) {
+    public void setParent(DictionaryCollection<? extends DictNode> _parent) {
         super.setParent(_parent);
 
         if (_parent instanceof ConWordCollection) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Nodes/ConjugationGenRule.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Nodes/ConjugationGenRule.java
@@ -80,15 +80,8 @@ public class ConjugationGenRule implements Comparable<ConjugationGenRule> {
      * Gets all entry pairs for classes/class values this rule applies to
      * @return 
      */
-    public Entry<Integer, Integer>[] getApplicableClasses() {
-        Object[] classVals = applyToClasses.entrySet().toArray();
-        Entry<Integer, Integer>[] ret = new Entry[classVals.length];
-        
-        for (int i = 0; i < classVals.length; i++) {
-            ret[i] = (Entry<Integer, Integer>)classVals[i];
-        }
-        
-        return ret;
+    public List<Entry<Integer, Integer>> getApplicableClasses() {
+        return new ArrayList<>(applyToClasses.entrySet());
     }
     
     /**

--- a/src/main/java/org/darisadesigns/polyglotlina/Nodes/DictNode.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Nodes/DictNode.java
@@ -31,7 +31,7 @@ import org.darisadesigns.polyglotlina.ManagersCollections.DictionaryCollection;
 public abstract class DictNode implements Comparable<DictNode> {
     protected String value;
     protected Integer id;    
-    protected DictionaryCollection parent = null;
+    protected DictionaryCollection<? extends DictNode> parent = null;
 
     @Override
     abstract public boolean equals(Object comp);
@@ -69,7 +69,7 @@ public abstract class DictNode implements Comparable<DictNode> {
         return id;
     }
 
-    public void setParent(DictionaryCollection _parent) {
+    public void setParent(DictionaryCollection<? extends DictNode> _parent) {
         parent = _parent;
     }
 

--- a/src/main/java/org/darisadesigns/polyglotlina/Nodes/PEntry.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Nodes/PEntry.java
@@ -56,23 +56,18 @@ public final class PEntry<K, V> implements Map.Entry<K, V> {
     
     @Override
     public boolean equals(Object comp) {
-        boolean ret = false;
-        
         if (this == comp) {
-            ret = true;
-        } else if (comp != null && getClass() == comp.getClass()) {
-            PEntry c = (PEntry)comp;
-            ret = this.key.equals(c.key) && this.value.equals(c.value);
+            return true;
         }
-        
-        return ret;
+        if (comp instanceof PEntry<?, ?> other) {
+            return Objects.equals(this.getKey(), other.getKey()) &&
+                Objects.equals(this.getValue(), other.getValue());
+        }
+        return false;
     }
 
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 17 * hash + Objects.hashCode(this.key);
-        hash = 17 * hash + Objects.hashCode(this.value);
-        return hash;
+        return Objects.hashCode(key) ^ Objects.hashCode(value);
     }
 }

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrDeclensionGenSimple.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrDeclensionGenSimple.java
@@ -132,7 +132,7 @@ public class ScrDeclensionGenSimple extends PDialog {
      */
     private void populateCombinedDecl() {
         ConjugationPair[] decs = core.getConjugationManager().getAllCombinedIds(typeId);
-        DefaultListModel decListModel = new DefaultListModel<>();
+        DefaultListModel<ConjugationPair> decListModel = new DefaultListModel<>();
         lstCombinedDec.setModel(decListModel);
 
         for (ConjugationPair curPair : decs) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrDeclensionSetup.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrDeclensionSetup.java
@@ -149,13 +149,14 @@ public final class ScrDeclensionSetup extends PDialog {
                     "Dimension", "ID"
                 }
         ) {
-            Class[] types =  {
-                java.lang.String.class, java.lang.Boolean.class, java.lang.Integer.class
-            };
+            private final Class<?>[] columntypes = { String.class, Boolean.class}; 
 
             @Override
-            public Class getColumnClass(int columnIndex) {
-                return types[columnIndex];
+            public Class<?> getColumnClass(int columnIndex) {
+                if (columnIndex >= 0 && columnIndex < columntypes.length) {
+                    return columntypes[columnIndex];
+                }
+                return super.getColumnClass(columnIndex);
             }
         };
 

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLogoDetails.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLogoDetails.java
@@ -1525,7 +1525,7 @@ public class ScrLogoDetails extends PFrame {
             return;
         }
 
-        ((DefaultListModel) lstRadicals.getModel()).
+        ((DefaultListModel<Object>) lstRadicals.getModel()).
                 remove(lstRadicals.getSelectedIndex());
     }//GEN-LAST:event_btnDelRadActionPerformed
 

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLogoQuickView.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrLogoQuickView.java
@@ -422,7 +422,7 @@ public final class ScrLogoQuickView extends PFrame {
      * @param logoId
      */
     public void setSelectedLogo(int logoId) {
-        DefaultListModel logoList = (DefaultListModel) lstLogos.getModel();
+        DefaultListModel<LogoNode> logoList = (DefaultListModel<LogoNode>) lstLogos.getModel();
 
         for (int i = 0; i < logoList.getSize(); i++) {
             LogoNode curNode = (LogoNode) logoList.get(i);

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrWinFontFolderSelector.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrWinFontFolderSelector.java
@@ -45,7 +45,7 @@ public class ScrWinFontFolderSelector extends PDialog {
     private void populateFonts() {
         var fontFiles = DesktopPFontHandler.searchForFonts(new File(System.getenv("windir") + "/WinSxS"));
 
-        var model = new DefaultListModel();
+        var model = new DefaultListModel<FontFileWrapper>();
         for (File file : fontFiles) {
             model.addElement(new FontFileWrapper(file));
         }

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrWordClasses.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrWordClasses.java
@@ -376,7 +376,7 @@ public final class ScrWordClasses extends PFrame {
             core.getOSHandler().getInfoBox().error("Unable to Delete", 
                     "Unable to delete property: " + e.getLocalizedMessage());
         }
-        DefaultListModel listModel = (DefaultListModel) lstProperties.getModel();
+        DefaultListModel<WordClass> listModel = (DefaultListModel<WordClass>) lstProperties.getModel();
         listModel.removeElement(prop);
 
         if (position == 0) {

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrWordClasses.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrWordClasses.java
@@ -28,6 +28,7 @@ import org.darisadesigns.polyglotlina.Desktop.CustomControls.PTextField;
 import org.darisadesigns.polyglotlina.Desktop.DesktopIOHandler;
 import org.darisadesigns.polyglotlina.DictCore;
 import org.darisadesigns.polyglotlina.Desktop.PolyGlot;
+import org.darisadesigns.polyglotlina.Nodes.DictNode;
 import org.darisadesigns.polyglotlina.Nodes.TypeNode;
 import org.darisadesigns.polyglotlina.Nodes.WordClassValue;
 import org.darisadesigns.polyglotlina.Nodes.WordClass;
@@ -294,10 +295,10 @@ public final class ScrWordClasses extends PFrame {
             typeChecks.values().forEach((checkBox) -> {
                 checkBox.setSelected(false);
             });
-            PTableModel tableModel = new PTableModel(new Object[]{"Values"}, 0);
+            PTableModel tableModel = new PTableModel(new String[]{"Values"});
             tblValues.setModel(tableModel);
         } else {
-            PTableModel tableModel = new PTableModel(new Object[]{"Values"}, 0);
+            PTableModel tableModel = new PTableModel(new String[]{"Values"});
             enableValues(true);
 
             // set name
@@ -308,7 +309,7 @@ public final class ScrWordClasses extends PFrame {
 
             // add property values
             curProp.getValues().forEach((curValue) -> {
-                tableModel.addRow(new Object[]{curValue});
+                tableModel.addRow(new DictNode[]{curValue});
             });
             
             // set checkboxes for types this applies to
@@ -404,7 +405,7 @@ public final class ScrWordClasses extends PFrame {
             return;
         }
 
-        tableModel.addRow(new Object[]{value});
+        tableModel.addRow(new DictNode[]{value});
         txtName.requestFocus();
     }
 

--- a/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrZompistLexiconGen.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Screens/ScrZompistLexiconGen.java
@@ -745,7 +745,7 @@ public class ScrZompistLexiconGen extends PFrame {
         }
         
         var displayWord = new ConWordDisplay(word, core);
-        ((DefaultListModel)lstImport.getModel()).addElement(displayWord);
+        ((DefaultListModel<ConWordDisplay>)lstImport.getModel()).addElement(displayWord);
         lstImport.ensureIndexIsVisible(lstImport.getModel().getSize() - 1);
     }
     
@@ -756,7 +756,7 @@ public class ScrZompistLexiconGen extends PFrame {
             new DesktopInfoBox(this).warning("No Word Selected", "No word selected to move back to values/swadesh lists.");
             return;
         }
-        var word = (ConWordDisplay)((DefaultListModel)lstImport.getModel()).get(wordIndex);
+        var word = ((DefaultListModel<ConWordDisplay>)lstImport.getModel()).get(wordIndex);
         
         addWord(word.getConWord().getValue());
         
@@ -765,7 +765,7 @@ public class ScrZompistLexiconGen extends PFrame {
             addSwadesh(swadesh);
         }
         
-        ((DefaultListModel)lstImport.getModel()).remove(wordIndex);
+        ((DefaultListModel<ConWordDisplay>)lstImport.getModel()).remove(wordIndex);
         
         if (wordIndex > 0) {
             lstImport.setSelectedIndex(wordIndex - 1);
@@ -777,7 +777,7 @@ public class ScrZompistLexiconGen extends PFrame {
     private void setEnableWordImport(boolean enable) {
         if (!enable) {
             cmbSwadesh.setSelectedIndex(0);
-            ((DefaultListModel)lstImport.getModel()).clear();
+            ((DefaultListModel<ConWordDisplay>)lstImport.getModel()).clear();
         }
         
         cmbSwadesh.setEnabled(enable);
@@ -1462,7 +1462,7 @@ public class ScrZompistLexiconGen extends PFrame {
         tblGeneratedValues.setModel(new DefaultTableModel());
         tableValuesUpdated();
         cmbSwadesh.setSelectedIndex(0);
-        ((DefaultListModel)lstImport.getModel()).clear();
+        ((DefaultListModel<ConWordDisplay>)lstImport.getModel()).clear();
     }//GEN-LAST:event_btnClearActionPerformed
 
     private void btnDelWordActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnDelWordActionPerformed


### PR DESCRIPTION
## Changes
- specified enumerations, maps, etc
- removed manual casting
- rewrote PTableModel to implement AbstractTableModel instead of DefaultListModel
    - this helped remove some additional casts to Vector
- rewrote PEntry hashCode to match documented requirements for Map.Entry
- simplified PEntry equality comparison function

Generally focused on removing the number of warnings and using more up to date code

## Testing
- [x] linux x86
- [x] linux aarch64
- [x] ~~win~~
- [x] mac