### PR TITLE
One 'any' checkbox per lexical class

### DIFF
--- a/docs/readme_developers.md
+++ b/docs/readme_developers.md
@@ -16,10 +16,10 @@ Note: GUI elements were built with the NetBeans GUI Builder.
 With recent updates to the maven build, you must select the profile of the system you are compiling on in order to build an installer
 
 | Profile | Architecture | Notes |
-| --- | --- | --- | --- |
-| linux | linux, x86 | |
-| linux-aarch64 | linux, ARM | |
-| windows | Windows 10/11 | |
+| --- | --- | --- |
+| linux | linux, x86 |
+| linux-aarch64 | linux, ARM | 
+| windows | Windows 10/11 |
 | mac-aarch64 | macos, ARM | Currently having issues with signing installer |
 | mac | macos, x86 | Untested, but build theoretically works |
 

--- a/src/main/java/org/darisadesigns/polyglotlina/Desktop/CustomControls/PClassCheckboxPanel.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Desktop/CustomControls/PClassCheckboxPanel.java
@@ -26,11 +26,16 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.Label;
 import java.awt.LayoutManager;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import javax.swing.BorderFactory;
 import javax.swing.Box.Filler;
 import javax.swing.JPanel;
@@ -44,7 +49,7 @@ import org.darisadesigns.polyglotlina.Desktop.PolyGlot;
  */
 public class PClassCheckboxPanel extends JPanel {
     private ConjugationGenRule rule = new ConjugationGenRule();
-    private final List<PCheckBox> applyClassesCheckboxes = new ArrayList<>();
+    private final HashMap<PCheckBox, List<PCheckBox>> applyClassesCheckboxes = new HashMap<>();
     private final TypeNode type;
     private GridBagConstraints gbc;
     private final PClassCheckboxPanel parent = this;
@@ -110,64 +115,100 @@ public class PClassCheckboxPanel extends JPanel {
     private void createCheckBoxes(DictCore core) {
         gbc.gridy = 2;
         gbc.anchor = GridBagConstraints.NORTHWEST;
-        
-        if (includeAll) {
-            this.addCheckBox("All", 
-                    "Apply to all classes", 
-                    (ItemEvent e) -> {
-                            PCheckBox thisBox = (PCheckBox)e.getSource();
-                            if (thisBox.isSelected()) {
-                                rule.addClassToFilterList(-1, -1);
-                                uncheckDisableClassChecks();
-                            } else {
-                                rule.removeClassFromFilterList(-1, -1);
-                                setEnabledClassChecks(true);
-                            }
-                        },
-                    -1, -1);
-        } else {
-            // if not used, set to dummy value which is not in menu
-            allCheckBox = new PCheckBox(nightMode);
-        }
 
         for (WordClass wordClass : core.getWordClassCollection().getClassesForType(type.getId())) {
-            wordClass.getValues().forEach((classValue)->{
-                this.addCheckBox(classValue.getValue(), 
-                            "Apply to " + wordClass.getValue() + ":" + classValue.getValue(), 
-                            new ItemListener() {
-                                final int thisClassId = wordClass.getId();
-                                final int classValueId = classValue.getId();
+            this.addTitle(wordClass.getValue() + ":");
+            
+            final var subCheckBoxes = wordClass.getValues().stream().map((classValue)->{
 
-                                @Override
-                                public void itemStateChanged(ItemEvent e) {
-                                    PCheckBox thisBox = (PCheckBox)e.getSource();
-                                    if (thisBox.isSelected()) {
-                                        rule.addClassToFilterList(thisClassId, classValueId);
-                                        init(core);
-                                    } else {
-                                        rule.removeClassFromFilterList(thisClassId, classValueId);
-                                    }
+                final Map.Entry<Integer, PCheckBox> checkBox = this.createCheckBox(classValue.getValue(), 
+                        "Apply to " + wordClass.getValue() + ":" + classValue.getValue(), 
+                        new ItemListener() {
+                            final int thisClassId = wordClass.getId();
+                            final int classValueId = classValue.getId();
+
+                            @Override
+                            public void itemStateChanged(ItemEvent e) {
+                                PCheckBox thisBox = (PCheckBox)e.getSource();
+                                if (thisBox.isSelected()) {
+                                    rule.addClassToFilterList(thisClassId, classValueId);
+                                    init(core);
+                                } else {
+                                    rule.removeClassFromFilterList(thisClassId, classValueId);
                                 }
-                            },
-                        wordClass.getId(),
-                        classValue.getId());
+                            }
+                        },
+                    wordClass.getId(),
+                    classValue.getId());
+            
+                checkBox.getValue().setSelected(rule.doesRuleApplyToClassValue(wordClass.getId(), classValue.getId(), true));
+                return checkBox;
+            }).collect(Collectors.toList());
+                        
+            final PCheckBox classCheckBox = createClassCheckbox(wordClass, new ItemListener() {
+                @Override
+                public void itemStateChanged(ItemEvent e) {
+                    PCheckBox thisBox = (PCheckBox)e.getSource();
+                    if (thisBox.isSelected()) {
+                        rule.addClassToFilterList(wordClass.getId(), -1);
+                        uncheckDisableClassChecks(thisBox);
+                    } else {
+                        rule.removeClassFromFilterList(wordClass.getId(), -1);
+                    }
+
+                    for (final PCheckBox child : applyClassesCheckboxes.get(thisBox)) {
+                        child.setEnabled(!thisBox.isSelected());
+                    }
+                }
             });
-        }
-        
-        // if this is the default rule without any rule set, disable checkboxes
-        allCheckBox.setEnabled(rule.getTypeId() != -1);
-        
-        if (allCheckBox.isSelected()) {
-            uncheckDisableClassChecks();
-        } else {
-            setEnabledClassChecks(rule.getTypeId() != -1);
+
+            this.addClassCheckBox(classCheckBox);
+            for (final Map.Entry<Integer, PCheckBox> entry : subCheckBoxes) {
+                this.addCheckBox(classCheckBox, entry);
+            }
+
+            if (rule.isUniversalInclusion(wordClass.getId()) && !classCheckBox.isSelected()) {
+                classCheckBox.doClick();
+            }
         }
     }
-    
-    private void addCheckBox(String title, String toolTip, ItemListener listener, int classId, int valueId) {
+
+    private void addTitle(String title) {
         gbc.weightx = 1;
         gbc.gridx = 0;
-        
+
+        final Label label = new Label();
+        label.setText(title);
+        this.add(label, gbc);
+
+        gbc.weightx = 9999;
+        gbc.gridx = 1;
+        this.add(new Filler(new Dimension(0,0),new Dimension(9999,9999),new Dimension(9999,9999)), gbc);  
+        gbc.gridy++;
+    }
+
+    private PCheckBox createClassCheckbox(WordClass wordClass, ItemListener listener) {
+        final PCheckBox classCheck = new PCheckBox() {
+            public void repaint() {
+                this.setSize(parent.getWidth(), 20);
+                super.repaint();
+            }
+        };
+
+        classCheck.setFont(checkBoxFont);
+        classCheck.setText("Any");
+        classCheck.setSelected(false);
+        classCheck.addItemListener(listener);
+        classCheck.setVerticalAlignment(javax.swing.SwingConstants.TOP);
+        classCheck.setHorizontalAlignment(javax.swing.SwingConstants.LEFT);
+
+        return classCheck;
+    }
+
+    /**
+     * @return entry of [classId, checkBox]
+     */
+    private Map.Entry<Integer, PCheckBox> createCheckBox(String title, String toolTip, ItemListener listener, int classId, int valueId) {
         final PCheckBox check = new PCheckBox(nightMode) {
             @Override
             public void repaint() {
@@ -175,20 +216,50 @@ public class PClassCheckboxPanel extends JPanel {
                 super.repaint();
             }
         };
+
         check.setFont(checkBoxFont);
         check.setText(title);
+        
         check.setSelected(rule.doesRuleApplyToClassValue(classId, valueId, true)); // st value before listener
         check.addItemListener(listener);
         check.setVerticalAlignment(javax.swing.SwingConstants.TOP);
         check.setHorizontalAlignment(javax.swing.SwingConstants.LEFT);
         check.setToolTipText(toolTip);
+
+        return Map.entry(classId, check);
+    }
+    
+    private void addClassCheckBox(PCheckBox classCheckBox) {
+        gbc.weightx = 1;
+        gbc.gridx = 0;
+    
+        this.add(classCheckBox, gbc);
+        applyClassesCheckboxes.put(classCheckBox, new ArrayList<>());
+        
+        gbc.weightx = 9999;
+        gbc.gridx = 1;
+        this.add(new Filler(new Dimension(0,0),new Dimension(9999,9999),new Dimension(9999,9999)), gbc);  
+        gbc.gridy++;
+    }
+
+    private void addCheckBox(PCheckBox parent, Map.Entry<Integer, PCheckBox> checkEntry) {
+        final int classId = checkEntry.getKey();
+        final PCheckBox check = checkEntry.getValue();
+        gbc.weightx = 1;
+        gbc.gridx = 0;
+    
         this.add(check, gbc);
         
         // do not add the "all" checkbox (with -1 ID) to the apply all list
         if (classId == -1) {
             allCheckBox = check;
         } else {
-            applyClassesCheckboxes.add(check);
+            final List<PCheckBox> oldChildren = applyClassesCheckboxes.get(parent);
+            if (oldChildren == null) {
+                applyClassesCheckboxes.put(parent, new ArrayList<>());
+            }
+
+            applyClassesCheckboxes.get(parent).add(check);
         }
         
         gbc.weightx = 9999;
@@ -202,16 +273,17 @@ public class PClassCheckboxPanel extends JPanel {
         // ignore. Set up internally only.
     }
 
-    private void uncheckDisableClassChecks() {
-        applyClassesCheckboxes.forEach((checkBox)->{
+    private void uncheckDisableClassChecks(PCheckBox parent) {
+        applyClassesCheckboxes.get(parent).forEach((checkBox)->{
             checkBox.setSelected(false);
         });
-        setEnabledClassChecks(false);
+
+        setEnabledClassChecks(parent, false);
     }
     
-    private void setEnabledClassChecks(boolean enable) {
-        applyClassesCheckboxes.forEach((checkBox)->{
-            checkBox.setEnabled(enable);
+    private void setEnabledClassChecks(PCheckBox parent, boolean enable) {
+        applyClassesCheckboxes.get(parent).forEach((checkBox)->{
+            checkBox.setSelected(enable);
         });
     }
     

--- a/src/main/java/org/darisadesigns/polyglotlina/Nodes/ConWord.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Nodes/ConWord.java
@@ -179,6 +179,16 @@ public class ConWord extends DictNode {
     }
 
     /**
+     * Tests whether thsi word has any class value applied to it of the given class.
+     * 
+     * @param classId class id to test
+     * @return true if classId has been set to some value
+     */
+    public boolean wordHasAnyClassValue(int classId) {
+        return classValues.containsKey(classId);
+    }
+
+    /**
      * Gets all freetext class values Purges values which no longer exist
      *
      * @return set of values with their IDs

--- a/src/main/java/org/darisadesigns/polyglotlina/Nodes/ConjugationGenRule.java
+++ b/src/main/java/org/darisadesigns/polyglotlina/Nodes/ConjugationGenRule.java
@@ -277,10 +277,24 @@ public class ConjugationGenRule implements Comparable<ConjugationGenRule> {
         if (classId != -1 && applyToClasses.containsKey(-1) && ! overrideDefault) {
             ret = true;
         } else if (applyToClasses.containsKey(classId)) {
-            ret = applyToClasses.get(classId).equals(valueId);
+            if (applyToClasses.get(classId) == -1) {
+                ret = true;
+            } else {
+                ret = applyToClasses.get(classId).equals(valueId);
+            }
         }
         
         return ret;
+    }
+
+    /**
+     * Returns true if this rule applies to all values of a given lexical class.
+     * @param classId the lexical class to test against
+     * @return true if the rule applies to all values of the given class.
+     */
+    public boolean isUniversalInclusion(int classId) {
+        final Integer value = applyToClasses.get(classId);
+        return value != null && value == -1;
     }
     
     /**
@@ -311,10 +325,13 @@ public class ConjugationGenRule implements Comparable<ConjugationGenRule> {
             for (Entry<Integer, Integer> curEntry : applyToClasses.entrySet()) {
                 int classId = curEntry.getKey();
                 
-                if (!word.wordHasClassValue(classId, curEntry.getValue())) {
-                    debugString += "    Word's class does not match filter values for rule. Rule will not be applied.\n";
-                    ret = false;
-                    break;
+                final boolean canApplySpecificValue = word.wordHasClassValue(classId, curEntry.getValue());
+                if (!canApplySpecificValue) {
+                    if (!word.wordHasAnyClassValue(classId) || curEntry.getValue() != -1) {
+                        debugString += "    Word's class does not match filter values for rule. Rule will not be applied.\n";
+                        ret = false;
+                        break;
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
### This pull request contains the following feature:
- Instead of displaying the 'All' checkbox in the conjugation autogeneration menu for all lexical classes, a checkbox is displayed separately for each lexical class (in addition to the checkboxes for the  values of the lexical class)
- Ticking the 'any' box ticks all the values of that lexical class and causes the rule to match all values of the lexical class.
- Additionally, the checkboxes are now grouped according to the class, with a header in between.

### Things to think about
- I removed the previous 'all' checkbox - however, the supporting code is still there, I did not remove any of the 'backend' functionality, just the UI bits. So if that is a feature that should be re-added, it can be done.
- Ticking the 'any' box saves the filter as classId = <whatever the lexical class id is> and valueId = -1 (similar to the classId = -1 with the previous 'all' system). Does this break some validation procedures? It did not seem to, at least any I could find but worth keeping in mind if there are side effects I did not think about.

### Pictures
Old PolyGlot:
<img width="188" height="331" alt="kuva" src="https://github.com/user-attachments/assets/799b1f62-412e-4fd4-bad5-b2200a257ced" />

After this PR:
<img width="184" height="473" alt="kuva" src="https://github.com/user-attachments/assets/35cd4329-aeef-41ae-8cea-416bdfd25aa3" />

Feel free to suggest edits, improvements, ask questions, whatnot! 